### PR TITLE
-pthread should not cause linking with libpthread

### DIFF
--- a/gcc/config/sol2.h
+++ b/gcc/config/sol2.h
@@ -157,7 +157,6 @@ along with GCC; see the file COPYING3.  If not see
 #undef LIB_SPEC
 #define LIB_SPEC \
   "%{!symbolic:\
-     %{pthreads|pthread:-lpthread} \
      %{p|pg:-ldl} -lc}"
 
 #ifndef CROSS_DIRECTORY_STRUCTURE


### PR DESCRIPTION
libpthread is a filter in illumos; all functionality has been migrated to libc.

Prevent gcc from linking with libpthread if -pthread[s] is passed as an option.

Some build systems such as meson/ninja pass this option.