### PR TITLE
fixup! i386: Save integer-passed arguments to the stack, to aid debuggers

### DIFF
--- a/gcc/config/i386/i386.opt
+++ b/gcc/config/i386/i386.opt
@@ -507,7 +507,7 @@ Use direct references against %gs when accessing tls data.
 
 msave-args
 Target Report Mask(SAVE_ARGS)
-Save integer arguments on the stack at function entry
+Save integer arguments on the stack at function entry.
 
 mforce-save-regs-using-mov
 Target Report Mask(FORCE_SAVE_REGS_USING_MOV)


### PR DESCRIPTION
Apparently the GCC test suite now checks the punctuation of help messages.

@rmustacc, @jlevon  How do we want to maintain these branches?  As patchsets in the manner of the old Hg Mq? or as a series of commits, or?

In other words, should this get rebased into the -msave-args implementation, or as a new commit (with a better message).  And which of those when bringing it forward to future versions?