### PR TITLE
7.3.0 saveargs fixes

### DIFF
--- a/gcc/config/i386/i386.c
+++ b/gcc/config/i386/i386.c
@@ -5899,7 +5899,7 @@ ix86_option_override_internal (bool main_args_p,
 	   & ~opts->x_ix86_isa_flags_explicit);
 
   if (!TARGET_64BIT_P (opts->x_ix86_isa_flags) && TARGET_SAVE_ARGS)
-    error ("-msave-args makes no sense in the 32-bit mode");
+    error ("-msave-args only works in x32 or 64-bit mode");
 
   /* Validate -mpreferred-stack-boundary= value or default it to
      PREFERRED_STACK_BOUNDARY_DEFAULT.  */

--- a/gcc/config/i386/i386.c
+++ b/gcc/config/i386/i386.c
@@ -13145,21 +13145,21 @@ static void
 ix86_emit_save_regs (void)
 {
   unsigned int regno;
+  struct ix86_frame &frame = cfun->machine->frame;
   rtx_insn *insn;
 
   if (TARGET_SAVE_ARGS)
     {
       int i;
-      int nsaved = ix86_nsaved_args ();
       int start = cfun->returns_struct;
 
-      for (i = start; i < start + nsaved; i++)
+      for (i = start; i < start + frame.nmsave_args; i++)
 	{
 	  regno = x86_64_int_parameter_registers[i];
 	  insn = emit_insn (gen_push (gen_rtx_REG (word_mode, regno)));
 	  RTX_FRAME_RELATED_P (insn) = 1;
 	}
-      if (nsaved % 2 != 0)
+      if (frame.nmsave_args % 2 != 0)
 	pro_epilogue_adjust_stack (stack_pointer_rtx, stack_pointer_rtx,
 				   GEN_INT (-UNITS_PER_WORD), -1, false);
     }
@@ -13243,22 +13243,21 @@ ix86_emit_save_reg_using_mov (machine_mode mode, unsigned int regno,
 /* Emit code to save registers using MOV insns.
    First register is stored at CFA - CFA_OFFSET.  */
 static void
-ix86_emit_save_regs_using_mov (struct ix86_frame *frame)
+ix86_emit_save_regs_using_mov (struct ix86_frame &frame)
 {
   unsigned int regno;
-  HOST_WIDE_INT cfa_offset = frame->arg_save_offset;
+  HOST_WIDE_INT cfa_offset = frame.arg_save_offset;
 
   if (TARGET_SAVE_ARGS)
     {
       int i;
-      int nsaved = ix86_nsaved_args ();
       int start = cfun->returns_struct;
 
       /* We deal with this twice? */
-      if (nsaved % 2 != 0)
+      if (frame.nmsave_args % 2 != 0)
 	cfa_offset -= UNITS_PER_WORD;
 
-      for (i = start + nsaved - 1; i >= start; i--)
+      for (i = start + frame.nmsave_args - 1; i >= start; i--)
 	{
 	  regno = x86_64_int_parameter_registers[i];
 	  ix86_emit_save_reg_using_mov(word_mode, regno, cfa_offset);
@@ -13266,7 +13265,7 @@ ix86_emit_save_regs_using_mov (struct ix86_frame *frame)
 	}
     }
 
-  cfa_offset = frame->reg_save_offset;
+  cfa_offset = frame.reg_save_offset;
 
   for (regno = 0; regno < FIRST_PSEUDO_REGISTER; regno++)
     if (GENERAL_REGNO_P (regno) && ix86_save_reg (regno, true))
@@ -14376,7 +14375,7 @@ ix86_expand_prologue (void)
 	       && (! TARGET_STACK_PROBE
 		   || frame.stack_pointer_offset < CHECK_STACK_LIMIT))
 	{
-	  ix86_emit_save_regs_using_mov (&frame);
+	  ix86_emit_save_regs_using_mov (frame);
 	  int_registers_saved = true;
 	}
     }
@@ -14619,7 +14618,7 @@ ix86_expand_prologue (void)
     }
 
   if (!int_registers_saved)
-    ix86_emit_save_regs_using_mov (&frame);
+    ix86_emit_save_regs_using_mov (frame);
   if (!sse_registers_saved)
     ix86_emit_save_sse_regs_using_mov (frame.sse_reg_save_offset);
 
@@ -15060,35 +15059,31 @@ ix86_expand_epilogue (int style)
       ix86_emit_restore_regs_using_pop ();
     }
 
-  if (TARGET_SAVE_ARGS) {
-    /*
-     * For each saved argument, emit a restore note, to make sure it happens
-     * correctly within the shrink wrapping (I think).
-     *
-     * Note that 'restore' in this case merely means the rule is the same as
-     * it was on function entry, not that we have actually done a register
-     * restore (which of course, we haven't).
-     *
-     * If we do not do this, the DWARF code will emit sufficient restores to
-     * provide balance on its own initiative, which in the presence of
-     * -fshrink-wrap may actually _introduce_ unbalance (whereby we only
-     * .cfi_offset a register sometimes, but will always .cfi_restore it.
-     * This will trip an assert.)
-     */
-    int start = cfun->returns_struct;
-    int nsaved = ix86_nsaved_args();
-    int i;
+  /*
+   * For each saved argument, emit a restore note, to make sure it happens
+   * correctly within the shrink wrapping (I think).
+   *
+   * Note that 'restore' in this case merely means the rule is the same as
+   * it was on function entry, not that we have actually done a register
+   * restore (which of course, we haven't).
+   *
+   * If we do not do this, the DWARF code will emit sufficient restores to
+   * provide balance on its own initiative, which in the presence of
+   * -fshrink-wrap may actually _introduce_ unbalance (whereby we only
+   * .cfi_offset a register sometimes, but will always .cfi_restore it.
+   * This will trip an assert.)
+   */
+  if (TARGET_SAVE_ARGS && frame.nmsave_args > 0) {
+	  int start = cfun->returns_struct;
+	  int i;
 
-    for (i = start + nsaved - 1; i >= start; i--)
-      queued_cfa_restores
-	= alloc_reg_note (REG_CFA_RESTORE,
+	  for (i = start + frame.nmsave_args - 1; i >= start; i--)
+		  queued_cfa_restores
+		      = alloc_reg_note (REG_CFA_RESTORE,
 			  gen_rtx_REG(Pmode,
-				      x86_64_int_parameter_registers[i]),
+			      x86_64_int_parameter_registers[i]),
 			  queued_cfa_restores);
-
-    gcc_assert(m->fs.fp_valid);
   }
-
 
   /* If we used a stack pointer and haven't already got rid of it,
      then do so now.  */

--- a/gcc/config/i386/i386.opt
+++ b/gcc/config/i386/i386.opt
@@ -507,7 +507,7 @@ Use direct references against %gs when accessing tls data.
 
 msave-args
 Target Report Mask(SAVE_ARGS)
-Save integer arguments on the stack at function entry
+Save integer arguments on the stack at function entry.
 
 mforce-save-regs-using-mov
 Target Report Mask(FORCE_SAVE_REGS_USING_MOV)

--- a/gcc/testsuite/gcc.dg/rtl/x86_64/pro_and_epilogue.c
+++ b/gcc/testsuite/gcc.dg/rtl/x86_64/pro_and_epilogue.c
@@ -1,5 +1,6 @@
 /* { dg-do compile { target { { i?86-*-* x86_64-*-* } && lp64 } } } */
 /* { dg-options "-fdump-rtl-pro_and_epilogue" } */
+/* { dg-skip-if "RTL in test doesn't save arguments" { *-*-* } "-msave-args" "" } */
 
 /* Lightly-modified dump of test.c.274r.split2 for x86_64.  */
 
@@ -95,7 +96,7 @@ int __RTL (startwith ("pro_and_epilogue")) test_1 (int i, int j, int k)
     (cnote 31 NOTE_INSN_DELETED)
   ) ;; insn-chain
   (crtl
-    (return_rtx 
+    (return_rtx
       (reg/i:SI ax)
     ) ;; return_rtx
   ) ;; crtl
@@ -107,4 +108,3 @@ int __RTL (startwith ("pro_and_epilogue")) test_1 (int i, int j, int k)
 
 /* We expect a jump_insn to "simple_return".  */
 /* { dg-final { scan-rtl-dump-times "simple_return" 2 "pro_and_epilogue" } }  */
-

--- a/gcc/testsuite/gcc.target/i386/pr78691-i386.c
+++ b/gcc/testsuite/gcc.target/i386/pr78691-i386.c
@@ -1,5 +1,6 @@
 /* PR tree-optimization/78691 */
 /* { dg-options "-Os -m16" } */
+/* { dg-skip-if "" { *-*-* } "-msave-args" "" } */
 
 int fn1(char *p1, char *p2) {
   int a;

--- a/gcc/testsuite/gcc.target/i386/pr80569.c
+++ b/gcc/testsuite/gcc.target/i386/pr80569.c
@@ -1,6 +1,7 @@
 /* PR target/80569 */
 /* { dg-do assemble } */
 /* { dg-options "-O2 -m16 -march=haswell" } */
+/* { dg-skip-if "" { *-*-* } "-msave-args" "" } */
 
 void load_kernel(void *setup_addr)
 {

--- a/gcc/testsuite/gcc.target/i386/retarg.c
+++ b/gcc/testsuite/gcc.target/i386/retarg.c
@@ -1,5 +1,6 @@
 /* { dg-do compile { target { ! ia32 } } } */
 /* { dg-options "-O2" } */
+/* { dg-skip-if "" { *-*-* } "-msave-args" "" } */
 
 #include <string.h>
 


### PR DESCRIPTION
A handful of fixes to make the GCC tests happier with -msave-args, though few if any meaningful fixes.
Note that -msave-args implication of -fno-omit-frame-pointer means the test results _in general_ are very loud (as they are with the frame-pointer patch anyway), but this at least makes differential testing with saveargs on and off much better.