### PR TITLE
i386: use the new-style retpoline thunk names for external thunks, be…

### DIFF
--- a/gcc/config/i386/i386.c
+++ b/gcc/config/i386/i386.c
@@ -12076,7 +12076,8 @@ indirect_thunk_name (char name[32], int regno, bool need_bnd_p,
   if (regno >= 0 && ret_p)
     gcc_unreachable ();
 
-  if (USE_HIDDEN_LINKONCE)
+  if (USE_HIDDEN_LINKONCE ||
+      (cfun && cfun->machine->indirect_branch_type == indirect_branch_thunk_extern))
     {
       const char *bnd = need_bnd_p ? "_bnd" : "";
       if (regno >= 0)


### PR DESCRIPTION
…cause nothing else will work

See https://github.com/illumos/gcc/issues/25 for details.