### PR TITLE
i386: use the new-style retpoline thunk names for external thunks, be…

### DIFF
--- a/gcc/config/i386/i386.c
+++ b/gcc/config/i386/i386.c
@@ -12099,7 +12099,8 @@ indirect_thunk_name (char name[32], unsigned int regno,
   if (regno != INVALID_REGNUM && regno != CX_REG && ret_p)
     gcc_unreachable ();
 
-  if (USE_HIDDEN_LINKONCE)
+  if (USE_HIDDEN_LINKONCE ||
+      (cfun && cfun->machine->indirect_branch_type == indirect_branch_thunk_extern))
     {
       const char *bnd = need_bnd_p ? "_bnd" : "";
       const char *ret = ret_p ? "return" : "indirect";


### PR DESCRIPTION
…cause nothing else will work.

Bringing the commit against the il-7_3_0 branch forwards to il-7_4_0