### PR TITLE
Use GNU backends for gcc-{ar,nm,ranlib} (il-7_3_0)

### DIFF
--- a/gcc/gcc-ar.c
+++ b/gcc/gcc-ar.c
@@ -187,12 +187,12 @@ main (int ac, char **av)
     }
 
   /* Find the wrapped binutils program.  */
-  exe_name = find_a_file (&target_path, PERSONALITY, X_OK);
+  exe_name = find_a_file (&target_path, "g" PERSONALITY, X_OK);
   if (!exe_name)
     {
-      const char *real_exe_name = PERSONALITY;
+      const char *real_exe_name = "g" PERSONALITY;
 #ifdef CROSS_DIRECTORY_STRUCTURE
-      real_exe_name = concat (target_machine, "-", PERSONALITY, NULL);
+      real_exe_name = concat (target_machine, "-", "g" PERSONALITY, NULL);
 #endif
       exe_name = find_a_file (&path, real_exe_name, X_OK);
       if (!exe_name)


### PR DESCRIPTION
Utilities such as `.../bin/gcc-ar` are wrappers around the GNU tools of the same name.
They end up exec()ing the real tool and get upset when the discovered tool is not the GNU variant.
Several build management systems such as `meson` will use `gcc-ar` and friends.

On OmniOS and OpenIndiana, the GNU tools `gar`, `granlib` and `gnm` are in the default path so let's make the wrappers look for those versions.