### PR TITLE
Always pass --32 to GNU AS backend unless -m64 was specified

### DIFF
--- a/gcc/config/i386/sol2-10.h
+++ b/gcc/config/i386/sol2-10.h
@@ -26,7 +26,7 @@ along with GCC; see the file COPYING3.  If not see
 #undef ASM_SPEC
 #ifdef USE_GAS
 #define ASM_SPEC "%{v:-V} %{Qy:} %{!Qn:-Qy} %{n} %{T} %{Ym,*} %{Yd,*} " \
-		 "%{Wa,*:%*} %{m32:--32} %{m64:--64} -s %(asm_cpu)"
+		 "%{Wa,*:%*} %{!m64:--32} %{m64:--64} -s %(asm_cpu)"
 #else
 #define ASM_SPEC "%{v:-V} %{Qy:} %{!Qn:-Qy} %{n} %{T} %{Ym,*} %{Yd,*} " \
 		 "%{Wa,*:%*} %{m32:-xarch=generic} %{m64:-xarch=generic64} " \

--- a/gcc/configure
+++ b/gcc/configure
@@ -22108,7 +22108,7 @@ foo:	.long	25
 	leal	foo@NTPOFF(%ecx), %eax'
 	tls_first_major=2
 	tls_first_minor=14
-	tls_as_opt=--fatal-warnings
+	tls_as_opt="-32 --fatal-warnings"
 	;;
   x86_64-*-*)
     conftest_s='

--- a/gcc/configure.ac
+++ b/gcc/configure.ac
@@ -2551,7 +2551,7 @@ foo:	.long	25
 	leal	foo@NTPOFF(%ecx), %eax'
 	tls_first_major=2
 	tls_first_minor=14
-	tls_as_opt=--fatal-warnings
+	tls_as_opt="-32 --fatal-warnings"
 	;;
   x86_64-*-*)
     conftest_s='


### PR DESCRIPTION
At present, gcc calls *GNU as* with --32 iff gcc was called with -m32, and it
calls GNU as with --64 iff gcc itself was called with -m64.

This works fine assuming that *GNU as* works in 32-bit mode by default but not
otherwise, and OmniOS bloody is moving towards the GNU binutils operating
in 64-bit mode by default.

This patch causes *GNU as* to be called with --64 if -m64 was passed to gcc
and to be called with --32 if -m64 was **NOT** passed to gcc.

Since the illumos gcc44 build outputs 32-bit by default, this causes the
backend assembler to be called with the correct options for both 32 and 64-bit builds.

A full illumos-gate build has been tested using a patched gcc44 as a shadow compiler.