### PR TITLE
Bring illumos patches into il-9_2_0 branch

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -573,7 +573,7 @@ STAGEautoprofile_TFLAGS = $(STAGE2_TFLAGS)
 STAGEautofeedback_CFLAGS = $(STAGE3_CFLAGS)
 STAGEautofeedback_TFLAGS = $(STAGE3_TFLAGS)
 
-do-compare = @do_compare@
+do-compare = $(srcdir)/contrib/compare-debug $$f1 $$f2
 do-compare3 = $(do-compare)
 
 # -----------------------------------------------

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+This is the GCC used for compiling illumos.
+
+The `il-*` branches contain the the patches used for building illumos, which
+are rebased versions of those used for Solaris/OpenSolaris, and then
+additional changes.  The versions actually in use are tagged with
+`il-VERSION-ilN` where _N_ version the illumos changes over the GCC version in
+question.
+
+The `wip/*` branches are works in progress and _should never be used_
+
+The `codesourcery/*` and `sun/*` branches contain the original GCCs as patched by
+CodeSourcery and Sun Microsystems for use compiling Solaris and OpenSolaris as
+was, and the GCCFSS patches of Sun's
+
+When building the compilers for illumos use the flags generally used are:
+
+i386
+~~~sh
+../../configure --prefix=/opt/gcc/$VER --with-as=/usr/bin/gas --with-gnu-as \
+   --with-ld=/usr/bin/ld --without-gnu-ld --enable-languages="c,c++,objc" \
+   --enable-shared  --with-mpfr-include=/usr/include/mpfr \
+   --with-gmp-include=/usr/include/gmp \
+   --with-pkgversion="Illumos $(git describe --all)" \
+   --with-bugurl="http://github.com/richlowe/gcc/issues"
+~~~
+
+sparc
+~~~sh
+../../configure --prefix=/opt/gcc/$VER --without-gnu-as --with-as=/usr/ccs/bin/as" \
+   --with-ld=/usr/bin/ld --without-gnu-ld --enable-languages="c,c++,objc" \
+   --enable-shared  --with-mpfr-include=/usr/include/mpfr \
+   --with-gmp-include=/usr/include/gmp \
+   --with-pkgversion="Illumos $(git describe --all)" \
+   --with-bugurl="http://github.com/richlowe/gcc/issues"
+~~~
+
+Please use the correct `--with-bugurl` and `--with-pkgversion` flags as
+appropriate for any modifications you make, but please also be sure that they
+accurately describe what is in use (ie, are not left at the defaults) either.

--- a/contrib/compare_tests
+++ b/contrib/compare_tests
@@ -108,8 +108,15 @@ elif [ -d "$1" -o -d "$2" ] ; then
 	usage "Must specify either two directories or two files"
 fi
 
-sed 's/^XFAIL/FAIL/; s/^ERROR/FAIL/; s/^XPASS/PASS/' < "$1" | awk '/^Running target / {target = $3} { if (target != "unix") { sub(/: /, "&"target": " ); }; print $0; }' | cut -c1-2000 >$tmp1
-sed 's/^XFAIL/FAIL/; s/^ERROR/FAIL/; s/^XPASS/PASS/' < "$2" | awk '/^Running target / {target = $3} { if (target != "unix") { sub(/: /, "&"target": " ); }; print $0; }' | cut -c1-2000 >$tmp2
+osrev=`uname -sr`
+if [ `expr "$osrev" : "SunOS 5."` -eq "8" ]; then
+   AWK=/usr/bin/nawk
+else
+    AWK=awk
+fi
+
+sed 's/^XFAIL/FAIL/; s/^ERROR/FAIL/; s/^XPASS/PASS/' < "$1" | $AWK '/^Running target / {target = $3} { if (target != "unix") { sub(/: /, "&"target": " ); }; print $0; }' | cut -c1-2000 >$tmp1
+sed 's/^XFAIL/FAIL/; s/^ERROR/FAIL/; s/^XPASS/PASS/' < "$2" | $AWK '/^Running target / {target = $3} { if (target != "unix") { sub(/: /, "&"target": " ); }; print $0; }' | cut -c1-2000 >$tmp2
 
 before=$tmp1
 now=$tmp2

--- a/fixincludes/fixinc.in
+++ b/fixincludes/fixinc.in
@@ -212,7 +212,7 @@ search_dirs=""
 
 while [ -n "$dirs" ] && [ $levels -gt 0 ]
 do
-  levels=`expr $levels - 1`
+  levels=`expr $levels - 1; true`
   newdirs=
   for d in $dirs
   do
@@ -341,7 +341,7 @@ if $LINKS; then
           cd $LIB
           while [ x$dirname != x ]; do
             component=`echo $dirname | sed -e 's|/.*$||'`
-            mkdir $component >/dev/null 2>&1
+            mkdir -p $component >/dev/null 2>&1
             cd $component
             dirmade=$dirmade/$component
             dirname=`echo $dirname | sed -e 's|[^/]*//*||'`

--- a/gcc/attribs.c
+++ b/gcc/attribs.c
@@ -544,6 +544,15 @@ decl_attributes (tree *node, tree attributes, int flags,
 	attributes = tree_cons (get_identifier ("no_icf"),  NULL, attributes);
     }
 
+  /* If the user passed -fno-clone-functions, all functions should be treated
+     as "noclone" */
+  if (TREE_CODE (*node) == FUNCTION_DECL
+      && !flag_clone_functions)
+    {
+      if (lookup_attribute ("noclone", attributes) == NULL)
+	attributes = tree_cons (get_identifier ("noclone"),  NULL, attributes);
+    }
+
   targetm.insert_attributes (*node, &attributes);
 
   /* Note that attributes on the same declaration are not necessarily

--- a/gcc/common.opt
+++ b/gcc/common.opt
@@ -2494,6 +2494,10 @@ fstrict-aliasing
 Common Report Var(flag_strict_aliasing) Optimization
 Assume strict aliasing rules apply.
 
+fstrict-calling-conventions
+Common Report Var(flag_strict_calling_conventions) Init(1)
+Use strict ABI calling conventions even for static functions
+
 fstrict-overflow
 Common Report
 Treat signed overflow as undefined.  Negated as -fwrapv -fwrapv-pointer.

--- a/gcc/common.opt
+++ b/gcc/common.opt
@@ -1122,6 +1122,11 @@ fcode-hoisting
 Common Report Var(flag_code_hoisting) Optimization
 Enable code hoisting.
 
+fclone-functions
+Common Report Var(flag_clone_functions) Init(1)
+Allow the compiler to clone functions to facilitate certain optimizations.
+Enabled by default.
+
 fcombine-stack-adjustments
 Common Report Var(flag_combine_stack_adjustments) Optimization
 Looks for opportunities to reduce stack adjustments and stack references.

--- a/gcc/config/i386/i386.c
+++ b/gcc/config/i386/i386.c
@@ -4358,7 +4358,7 @@ ix86_option_override_internal (bool main_args_p,
 	   & ~opts->x_ix86_isa_flags_explicit);
 
   if (!TARGET_64BIT_P (opts->x_ix86_isa_flags) && TARGET_SAVE_ARGS)
-    error ("-msave-args makes no sense in the 32-bit mode");
+    error ("-msave-args only works in x32 or 64-bit mode");
 
   /* Validate -mpreferred-stack-boundary= value or default it to
      PREFERRED_STACK_BOUNDARY_DEFAULT.  */

--- a/gcc/config/i386/i386.c
+++ b/gcc/config/i386/i386.c
@@ -4812,6 +4812,15 @@ ix86_option_override_internal (bool main_args_p,
       free (str);
     }
 
+  /*
+   * We never want to omit the frame pointer, regardless of the optimisation
+   * level or options to gcc - we like stack traces too much and it is of
+   * questionable benefit anyway, even on i386.
+   */
+
+  flag_omit_frame_pointer = 0;
+  opts->x_flag_omit_frame_pointer = 0;
+
   /* Save the initial options in case the user does function specific
      options.  */
   if (main_args_p)

--- a/gcc/config/i386/i386.c
+++ b/gcc/config/i386/i386.c
@@ -6620,6 +6620,7 @@ ix86_function_regparm (const_tree type, const_tree decl)
 	 and callee not, or vice versa.  Instead look at whether the callee
 	 is optimized or not.  */
       if (target && opt_for_fn (target->decl, optimize)
+	  && !flag_strict_calling_conventions
 	  && !(profile_flag && !flag_fentry))
 	{
 	  cgraph_local_info *i = &target->local;
@@ -6717,6 +6718,7 @@ ix86_function_sseregparm (const_tree type, const_tree decl, bool warn)
       /* TARGET_SSE_MATH */
       && (target_opts_for_fn (target->decl)->x_ix86_fpmath & FPMATH_SSE)
       && opt_for_fn (target->decl, optimize)
+      && !flag_strict_calling_conventions
       && !(profile_flag && !flag_fentry))
     {
       cgraph_local_info *i = &target->local;

--- a/gcc/config/i386/i386.c
+++ b/gcc/config/i386/i386.c
@@ -10632,7 +10632,8 @@ indirect_thunk_name (char name[32], unsigned int regno,
   if (regno != INVALID_REGNUM && regno != CX_REG && ret_p)
     gcc_unreachable ();
 
-  if (USE_HIDDEN_LINKONCE)
+  if (USE_HIDDEN_LINKONCE ||
+      (cfun && cfun->machine->indirect_branch_type == indirect_branch_thunk_extern))
     {
       const char *prefix;
 

--- a/gcc/config/i386/i386.c
+++ b/gcc/config/i386/i386.c
@@ -857,6 +857,8 @@ static unsigned int ix86_minimum_incoming_stack_boundary (bool);
 
 static enum calling_abi ix86_function_abi (const_tree);
 
+static int ix86_nsaved_args (void);
+static rtx_def* pro_epilogue_adjust_stack (rtx, rtx, rtx, int, bool);
 
 #ifndef SUBTARGET32_DEFAULT_CPU
 #define SUBTARGET32_DEFAULT_CPU "i386"
@@ -4354,6 +4356,9 @@ ix86_option_override_internal (bool main_args_p,
     opts->x_ix86_isa_flags
       &= ~((OPTION_MASK_ISA_BMI | OPTION_MASK_ISA_BMI2 | OPTION_MASK_ISA_TBM)
 	   & ~opts->x_ix86_isa_flags_explicit);
+
+  if (!TARGET_64BIT_P (opts->x_ix86_isa_flags) && TARGET_SAVE_ARGS)
+    error ("-msave-args makes no sense in the 32-bit mode");
 
   /* Validate -mpreferred-stack-boundary= value or default it to
      PREFERRED_STACK_BOUNDARY_DEFAULT.  */
@@ -10495,7 +10500,7 @@ ix86_can_use_return_insn_p (void)
 
   struct ix86_frame &frame = cfun->machine->frame;
   return (frame.stack_pointer_offset == UNITS_PER_WORD
-	  && (frame.nregs + frame.nsseregs) == 0);
+	  && (frame.nmsave_args + frame.nregs + frame.nsseregs) == 0);
 }
 
 /* Value should be nonzero if functions must have frame pointers.
@@ -10517,6 +10522,9 @@ ix86_frame_pointer_required (void)
 
   /* For older 32-bit runtimes setjmp requires valid frame-pointer.  */
   if (TARGET_32BIT_MS_ABI && cfun->calls_setjmp)
+    return true;
+
+  if (TARGET_SAVE_ARGS)
     return true;
 
   /* Win64 SEH, very large frames need a frame-pointer as maximum stack
@@ -11367,6 +11375,7 @@ ix86_compute_frame_layout (void)
 
   frame->nregs = ix86_nsaved_regs ();
   frame->nsseregs = ix86_nsaved_sseregs ();
+  frame->nmsave_args = ix86_nsaved_args ();
 
   /* 64-bit MS ABI seem to require stack alignment to be always 16,
      except for function prologues, leaf functions and when the defult
@@ -11435,7 +11444,8 @@ ix86_compute_frame_layout (void)
     }
 
   frame->save_regs_using_mov
-    = (TARGET_PROLOGUE_USING_MOVE && m->use_fast_prologue_epilogue
+    = ((TARGET_FORCE_SAVE_REGS_USING_MOV ||
+	(TARGET_PROLOGUE_USING_MOVE && m->use_fast_prologue_epilogue))
        /* If static stack checking is enabled and done with probes,
 	  the registers need to be saved before allocating the frame.  */
        && flag_stack_check != STATIC_BUILTIN_STACK_CHECK);
@@ -11454,6 +11464,13 @@ ix86_compute_frame_layout (void)
 
   /* The traditional frame pointer location is at the top of the frame.  */
   frame->hard_frame_pointer_offset = offset;
+
+  if (TARGET_SAVE_ARGS)
+    {
+      offset += frame->nmsave_args * UNITS_PER_WORD;
+      offset += (frame->nmsave_args % 2) * UNITS_PER_WORD;
+    }
+  frame->arg_save_offset = offset;
 
   /* Register save area */
   offset += frame->nregs * UNITS_PER_WORD;
@@ -11593,7 +11610,7 @@ ix86_compute_frame_layout (void)
   /* Size prologue needs to allocate.  */
   to_allocate = offset - frame->sse_reg_save_offset;
 
-  if ((!to_allocate && frame->nregs <= 1)
+  if ((!TARGET_SAVE_ARGS && !to_allocate && frame->nregs <= 1)
       || (TARGET_64BIT && to_allocate >= HOST_WIDE_INT_C (0x80000000))
       /* If stack clash probing needs a loop, then it needs a
 	 scratch register.  But the returned register is only guaranteed
@@ -11612,7 +11629,11 @@ ix86_compute_frame_layout (void)
     {
       frame->red_zone_size = to_allocate;
       if (frame->save_regs_using_mov)
+	{
 	frame->red_zone_size += frame->nregs * UNITS_PER_WORD;
+	  frame->red_zone_size += frame->nmsave_args * UNITS_PER_WORD;
+	  frame->red_zone_size += (frame->nmsave_args % 2) * UNITS_PER_WORD;
+	}
       if (frame->red_zone_size > RED_ZONE_SIZE - RED_ZONE_RESERVE)
 	frame->red_zone_size = RED_ZONE_SIZE - RED_ZONE_RESERVE;
     }
@@ -11642,6 +11663,23 @@ ix86_compute_frame_layout (void)
 	     frame that is addressable with 8-bit offsets.  */
 	  frame->hard_frame_pointer_offset = frame->stack_pointer_offset - 128;
 	}
+    }
+
+
+  if (getenv("DEBUG_FRAME_STUFF") != NULL)
+    {
+      printf("nmsave_args: %d\n", frame->nmsave_args);
+      printf("nsseregs: %d\n", frame->nsseregs);
+      printf("nregs: %d\n", frame->nregs);
+
+      printf("frame_pointer_offset: %llx\n", frame->frame_pointer_offset);
+      printf("hard_frame_pointer_offset: %llx\n", frame->hard_frame_pointer_offset);
+      printf("stack_pointer_offset: %llx\n", frame->stack_pointer_offset);
+      printf("hfp_save_offset: %llx\n", frame->hfp_save_offset);
+      printf("arg_save_offset: %llx\n", frame->arg_save_offset);
+      printf("reg_save_offset: %llx\n", frame->reg_save_offset);
+      printf("sse_reg_save_offset: %llx\n", frame->sse_reg_save_offset);
+
     }
 }
 
@@ -11859,6 +11897,24 @@ ix86_emit_save_regs (void)
   unsigned int regno;
   rtx_insn *insn;
 
+  if (TARGET_SAVE_ARGS)
+    {
+      int i;
+      int nsaved = ix86_nsaved_args ();
+      int start = cfun->returns_struct;
+
+      for (i = start; i < start + nsaved; i++)
+	{
+	  regno = x86_64_int_parameter_registers[i];
+	  insn = emit_insn (gen_push (gen_rtx_REG (word_mode, regno)));
+	  RTX_FRAME_RELATED_P (insn) = 1;
+	}
+      if (nsaved % 2 != 0)
+	pro_epilogue_adjust_stack (stack_pointer_rtx, stack_pointer_rtx,
+				   GEN_INT (-UNITS_PER_WORD), -1, false);
+    }
+
+
   for (regno = FIRST_PSEUDO_REGISTER - 1; regno-- > 0; )
     if (GENERAL_REGNO_P (regno) && ix86_save_reg (regno, true, true))
       {
@@ -11945,9 +12001,30 @@ ix86_emit_save_reg_using_mov (machine_mode mode, unsigned int regno,
 /* Emit code to save registers using MOV insns.
    First register is stored at CFA - CFA_OFFSET.  */
 static void
-ix86_emit_save_regs_using_mov (HOST_WIDE_INT cfa_offset)
+ix86_emit_save_regs_using_mov (const struct ix86_frame *frame)
 {
   unsigned int regno;
+  HOST_WIDE_INT cfa_offset = frame->arg_save_offset;
+
+  if (TARGET_SAVE_ARGS)
+    {
+      int i;
+      int nsaved = ix86_nsaved_args ();
+      int start = cfun->returns_struct;
+
+      /* We deal with this twice? */
+      if (nsaved % 2 != 0)
+	cfa_offset -= UNITS_PER_WORD;
+
+      for (i = start + nsaved - 1; i >= start; i--)
+	{
+	  regno = x86_64_int_parameter_registers[i];
+	  ix86_emit_save_reg_using_mov(word_mode, regno, cfa_offset);
+	  cfa_offset -= UNITS_PER_WORD;
+	}
+    }
+
+  cfa_offset = frame->reg_save_offset;
 
   for (regno = 0; regno < FIRST_PSEUDO_REGISTER; regno++)
     if (GENERAL_REGNO_P (regno) && ix86_save_reg (regno, true, true))
@@ -13432,7 +13509,7 @@ ix86_expand_prologue (void)
 	}
     }
 
-  int_registers_saved = (frame.nregs == 0);
+  int_registers_saved = (frame.nregs == 0 && frame.nmsave_args == 0);
   sse_registers_saved = (frame.nsseregs == 0);
   save_stub_call_needed = (m->call_ms2sysv);
   gcc_assert (sse_registers_saved || !save_stub_call_needed);
@@ -13474,6 +13551,7 @@ ix86_expand_prologue (void)
 	{
 	  ix86_emit_save_regs ();
 	  int_registers_saved = true;
+
 	  gcc_assert (m->fs.sp_offset == frame.reg_save_offset);
 	}
 
@@ -13485,7 +13563,7 @@ ix86_expand_prologue (void)
 	       && (! TARGET_STACK_PROBE
 		   || frame.stack_pointer_offset < CHECK_STACK_LIMIT))
 	{
-	  ix86_emit_save_regs_using_mov (frame.reg_save_offset);
+	  ix86_emit_save_regs_using_mov (&frame);
 	  int_registers_saved = true;
 	}
     }
@@ -13777,7 +13855,7 @@ ix86_expand_prologue (void)
     }
 
   if (!int_registers_saved)
-    ix86_emit_save_regs_using_mov (frame.reg_save_offset);
+    ix86_emit_save_regs_using_mov (&frame);
   if (!sse_registers_saved)
     ix86_emit_save_sse_regs_using_mov (frame.sse_reg_save_offset);
   else if (save_stub_call_needed)
@@ -13812,6 +13890,7 @@ ix86_expand_prologue (void)
      relative to the value of the stack pointer at the end of the function
      prologue, and moving instructions that access redzone area via frame
      pointer inside push sequence violates this assumption.  */
+  /* XXX: We may wish to do this when SAVE_ARGS in general */
   if (frame_pointer_needed && frame.red_zone_size)
     emit_insn (gen_memory_blockage ());
 
@@ -14195,6 +14274,7 @@ ix86_expand_epilogue (int style)
 
   /* See the comment about red zone and frame
      pointer usage in ix86_expand_prologue.  */
+  /* XXX: We may want to do this when SAVE_ARGS in general */
   if (frame_pointer_needed && frame.red_zone_size)
     emit_insn (gen_memory_blockage ());
 
@@ -14425,6 +14505,36 @@ ix86_expand_epilogue (int style)
 
       ix86_emit_restore_regs_using_pop ();
     }
+
+  if (TARGET_SAVE_ARGS) {
+    /*
+     * For each saved argument, emit a restore note, to make sure it happens
+     * correctly within the shrink wrapping (I think).
+     *
+     * Note that 'restore' in this case merely means the rule is the same as
+     * it was on function entry, not that we have actually done a register
+     * restore (which of course, we haven't).
+     *
+     * If we do not do this, the DWARF code will emit sufficient restores to
+     * provide balance on its own initiative, which in the presence of
+     * -fshrink-wrap may actually _introduce_ unbalance (whereby we only
+     * .cfi_offset a register sometimes, but will always .cfi_restore it.
+     * This will trip an assert.)
+     */
+    int start = cfun->returns_struct;
+    int nsaved = ix86_nsaved_args();
+    int i;
+
+    for (i = start + nsaved - 1; i >= start; i--)
+      queued_cfa_restores
+	= alloc_reg_note (REG_CFA_RESTORE,
+			  gen_rtx_REG(Pmode,
+				      x86_64_int_parameter_registers[i]),
+			  queued_cfa_restores);
+
+    gcc_assert(m->fs.fp_valid);
+  }
+
 
   /* If we used a stack pointer and haven't already got rid of it,
      then do so now.  */
@@ -15479,6 +15589,19 @@ ix86_cannot_force_const_mem (machine_mode mode, rtx x)
 
   return !ix86_legitimate_constant_p (mode, x);
 }
+
+/* Return number of arguments to be saved on the stack with
+   -msave-args.  */
+
+static int
+ix86_nsaved_args (void)
+{
+  if (TARGET_SAVE_ARGS)
+    return crtl->args.info.regno - cfun->returns_struct;
+  else
+    return 0;
+}
+
 
 /*  Nonzero if the symbol is marked as dllimport, or as stub-variable,
     otherwise zero.  */

--- a/gcc/config/i386/i386.c
+++ b/gcc/config/i386/i386.c
@@ -11904,21 +11904,21 @@ static void
 ix86_emit_save_regs (void)
 {
   unsigned int regno;
+  struct ix86_frame &frame = cfun->machine->frame;
   rtx_insn *insn;
 
   if (TARGET_SAVE_ARGS)
     {
       int i;
-      int nsaved = ix86_nsaved_args ();
       int start = cfun->returns_struct;
 
-      for (i = start; i < start + nsaved; i++)
+      for (i = start; i < start + frame.nmsave_args; i++)
 	{
 	  regno = x86_64_int_parameter_registers[i];
 	  insn = emit_insn (gen_push (gen_rtx_REG (word_mode, regno)));
 	  RTX_FRAME_RELATED_P (insn) = 1;
 	}
-      if (nsaved % 2 != 0)
+      if (frame.nmsave_args % 2 != 0)
 	pro_epilogue_adjust_stack (stack_pointer_rtx, stack_pointer_rtx,
 				   GEN_INT (-UNITS_PER_WORD), -1, false);
     }
@@ -12010,22 +12010,21 @@ ix86_emit_save_reg_using_mov (machine_mode mode, unsigned int regno,
 /* Emit code to save registers using MOV insns.
    First register is stored at CFA - CFA_OFFSET.  */
 static void
-ix86_emit_save_regs_using_mov (const struct ix86_frame *frame)
+ix86_emit_save_regs_using_mov (const struct ix86_frame &frame)
 {
   unsigned int regno;
-  HOST_WIDE_INT cfa_offset = frame->arg_save_offset;
+  HOST_WIDE_INT cfa_offset = frame.arg_save_offset;
 
   if (TARGET_SAVE_ARGS)
     {
       int i;
-      int nsaved = ix86_nsaved_args ();
       int start = cfun->returns_struct;
 
       /* We deal with this twice? */
-      if (nsaved % 2 != 0)
+      if (frame.nmsave_args % 2 != 0)
 	cfa_offset -= UNITS_PER_WORD;
 
-      for (i = start + nsaved - 1; i >= start; i--)
+      for (i = start + frame.nmsave_args - 1; i >= start; i--)
 	{
 	  regno = x86_64_int_parameter_registers[i];
 	  ix86_emit_save_reg_using_mov(word_mode, regno, cfa_offset);
@@ -12033,7 +12032,7 @@ ix86_emit_save_regs_using_mov (const struct ix86_frame *frame)
 	}
     }
 
-  cfa_offset = frame->reg_save_offset;
+  cfa_offset = frame.reg_save_offset;
 
   for (regno = 0; regno < FIRST_PSEUDO_REGISTER; regno++)
     if (GENERAL_REGNO_P (regno) && ix86_save_reg (regno, true, true))
@@ -13572,7 +13571,7 @@ ix86_expand_prologue (void)
 	       && (! TARGET_STACK_PROBE
 		   || frame.stack_pointer_offset < CHECK_STACK_LIMIT))
 	{
-	  ix86_emit_save_regs_using_mov (&frame);
+	  ix86_emit_save_regs_using_mov (frame);
 	  int_registers_saved = true;
 	}
     }
@@ -13864,7 +13863,7 @@ ix86_expand_prologue (void)
     }
 
   if (!int_registers_saved)
-    ix86_emit_save_regs_using_mov (&frame);
+    ix86_emit_save_regs_using_mov (frame);
   if (!sse_registers_saved)
     ix86_emit_save_sse_regs_using_mov (frame.sse_reg_save_offset);
   else if (save_stub_call_needed)
@@ -14515,35 +14514,31 @@ ix86_expand_epilogue (int style)
       ix86_emit_restore_regs_using_pop ();
     }
 
-  if (TARGET_SAVE_ARGS) {
-    /*
-     * For each saved argument, emit a restore note, to make sure it happens
-     * correctly within the shrink wrapping (I think).
-     *
-     * Note that 'restore' in this case merely means the rule is the same as
-     * it was on function entry, not that we have actually done a register
-     * restore (which of course, we haven't).
-     *
-     * If we do not do this, the DWARF code will emit sufficient restores to
-     * provide balance on its own initiative, which in the presence of
-     * -fshrink-wrap may actually _introduce_ unbalance (whereby we only
-     * .cfi_offset a register sometimes, but will always .cfi_restore it.
-     * This will trip an assert.)
-     */
-    int start = cfun->returns_struct;
-    int nsaved = ix86_nsaved_args();
-    int i;
+  /*
+   * For each saved argument, emit a restore note, to make sure it happens
+   * correctly within the shrink wrapping (I think).
+   *
+   * Note that 'restore' in this case merely means the rule is the same as
+   * it was on function entry, not that we have actually done a register
+   * restore (which of course, we haven't).
+   *
+   * If we do not do this, the DWARF code will emit sufficient restores to
+   * provide balance on its own initiative, which in the presence of
+   * -fshrink-wrap may actually _introduce_ unbalance (whereby we only
+   * .cfi_offset a register sometimes, but will always .cfi_restore it.
+   * This will trip an assert.)
+   */
+  if (TARGET_SAVE_ARGS && frame.nmsave_args > 0) {
+	  int start = cfun->returns_struct;
+	  int i;
 
-    for (i = start + nsaved - 1; i >= start; i--)
-      queued_cfa_restores
-	= alloc_reg_note (REG_CFA_RESTORE,
+	  for (i = start + frame.nmsave_args - 1; i >= start; i--)
+		  queued_cfa_restores
+		      = alloc_reg_note (REG_CFA_RESTORE,
 			  gen_rtx_REG(Pmode,
-				      x86_64_int_parameter_registers[i]),
+			      x86_64_int_parameter_registers[i]),
 			  queued_cfa_restores);
-
-    gcc_assert(m->fs.fp_valid);
   }
-
 
   /* If we used a stack pointer and haven't already got rid of it,
      then do so now.  */

--- a/gcc/config/i386/i386.h
+++ b/gcc/config/i386/i386.h
@@ -2530,6 +2530,11 @@ enum avx_u128_state
 
    saved frame pointer			if frame_pointer_needed
 					<- HARD_FRAME_POINTER
+
+   [-msave-args]			<- arg_save_offset
+
+   [saveargs padding]
+
    [saved regs]
 					<- reg_save_offset
    [padding0]
@@ -2563,6 +2568,7 @@ enum avx_u128_state
   */
 struct GTY(()) ix86_frame
 {
+  int nmsave_args;
   int nsseregs;
   int nregs;
   int va_arg_size;
@@ -2574,6 +2580,7 @@ struct GTY(()) ix86_frame
   HOST_WIDE_INT hard_frame_pointer_offset;
   HOST_WIDE_INT stack_pointer_offset;
   HOST_WIDE_INT hfp_save_offset;
+  HOST_WIDE_INT arg_save_offset;
   HOST_WIDE_INT reg_save_offset;
   HOST_WIDE_INT stack_realign_allocate;
   HOST_WIDE_INT stack_realign_offset;

--- a/gcc/config/i386/i386.opt
+++ b/gcc/config/i386/i386.opt
@@ -509,6 +509,16 @@ mtls-direct-seg-refs
 Target Report Mask(TLS_DIRECT_SEG_REFS)
 Use direct references against %gs when accessing tls data.
 
+msave-args
+Target Report Mask(SAVE_ARGS)
+Save integer arguments on the stack at function entry
+
+mforce-save-regs-using-mov
+Target Report Mask(FORCE_SAVE_REGS_USING_MOV)
+Save registers using push in function prologues.  This is intentionally
+undocumented and used for msave-args testing.
+
+
 mtune=
 Target RejectNegative Negative(mtune=) Joined Var(ix86_tune_string)
 Schedule code for given CPU.

--- a/gcc/config/i386/i386.opt
+++ b/gcc/config/i386/i386.opt
@@ -511,7 +511,7 @@ Use direct references against %gs when accessing tls data.
 
 msave-args
 Target Report Mask(SAVE_ARGS)
-Save integer arguments on the stack at function entry
+Save integer arguments on the stack at function entry.
 
 mforce-save-regs-using-mov
 Target Report Mask(FORCE_SAVE_REGS_USING_MOV)

--- a/gcc/config/sol2-c.c
+++ b/gcc/config/sol2-c.c
@@ -67,7 +67,7 @@ static const format_char_info cmn_err_char_table[] =
   { "c",   0, STD_C89, { T89_C,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-w",   "",   NULL },
   { "p",   1, STD_C89, { T89_V,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-w",   "c",  NULL },
   { "s",   1, STD_C89, { T89_C,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-wp",  "cR", NULL },
-  { "b",   0, STD_C89, { T89_I,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-w",   "",   &bitfield_string_type },
+  { "b",   0, STD_C89, { T89_I,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-w0",  "",   &bitfield_string_type },
   { NULL,  0, STD_C89, NOLENGTHS, NULL, NULL, NULL }
 };
 

--- a/gcc/config/sol2-c.c
+++ b/gcc/config/sol2-c.c
@@ -40,7 +40,10 @@ static const format_length_info cmn_err_length_specs[] =
 
 static const format_flag_spec cmn_err_flag_specs[] =
 {
+  { '0',  0, 0, 0, N_("'0' flag"),        N_("the '0' flag"),                     STD_C89 },
+  { '-',  0, 0, 0, N_("'-' flag"),        N_("the '-' flag"),                     STD_C89 },
   { 'w',  0, 0, 0, N_("field width"),     N_("field width in printf format"),     STD_C89 },
+  { 'p',  0, 0, 0, N_("precision"),       N_("precision in printf format"),       STD_C89 },
   { 'L',  0, 0, 0, N_("length modifier"), N_("length modifier in printf format"), STD_C89 },
   { 0, 0, 0, 0, NULL, NULL, STD_C89 }
 };
@@ -48,6 +51,7 @@ static const format_flag_spec cmn_err_flag_specs[] =
 
 static const format_flag_pair cmn_err_flag_pairs[] =
 {
+  { '0', '-', 1, 0 },
   { 0, 0, 0, 0 }
 };
 
@@ -57,21 +61,21 @@ static const format_char_info bitfield_string_type =
 static const format_char_info cmn_err_char_table[] =
 {
   /* C89 conversion specifiers.  */
-  { "dD",  0, STD_C89, { T89_I,   BADLEN,  BADLEN,  T89_L,   T9L_LL,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "w",  "",   NULL },
-  { "oOxX",0, STD_C89, { T89_UI,  BADLEN,  BADLEN,  T89_UL,  T9L_ULL, BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "w",  "",   NULL },
-  { "u",   0, STD_C89, { T89_UI,  BADLEN,  BADLEN,  T89_UL,  T9L_ULL, BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "w",  "",   NULL },
-  { "c",   0, STD_C89, { T89_C,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "w",  "",   NULL },
-  { "p",   1, STD_C89, { T89_V,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "w", "c",  NULL },
-  { "s",   1, STD_C89, { T89_C,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "w",  "cR", NULL },
-  { "b",   0, STD_C89, { T89_I,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "w",   "",   &bitfield_string_type },
+  { "dD",  0, STD_C89, { T89_I,   BADLEN,  BADLEN,  T89_L,   T9L_LL,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-wp0", "",   NULL },
+  { "oOxX",0, STD_C89, { T89_UI,  BADLEN,  BADLEN,  T89_UL,  T9L_ULL, BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-wp0", "",   NULL },
+  { "u",   0, STD_C89, { T89_UI,  BADLEN,  BADLEN,  T89_UL,  T9L_ULL, BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-wp0", "",   NULL },
+  { "c",   0, STD_C89, { T89_C,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-w",   "",   NULL },
+  { "p",   1, STD_C89, { T89_V,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-w",   "c",  NULL },
+  { "s",   1, STD_C89, { T89_C,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-wp",  "cR", NULL },
+  { "b",   0, STD_C89, { T89_I,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-w",   "",   &bitfield_string_type },
   { NULL,  0, STD_C89, NOLENGTHS, NULL, NULL, NULL }
 };
 
 EXPORTED_CONST format_kind_info solaris_format_types[] = {
-  { "cmn_err",  cmn_err_length_specs,  cmn_err_char_table, "", NULL,
+  { "cmn_err",  cmn_err_length_specs,  cmn_err_char_table, "0-", NULL,
     cmn_err_flag_specs, cmn_err_flag_pairs,
     FMT_FLAG_ARG_CONVERT|FMT_FLAG_EMPTY_PREC_OK,
-    'w', 0, 0, 0, 'L', 0,
+    'w', 0, 'p', 0, 'L', 0,
     &integer_type_node, &integer_type_node
   }
 };

--- a/gcc/config/sol2.h
+++ b/gcc/config/sol2.h
@@ -161,7 +161,6 @@ along with GCC; see the file COPYING3.  If not see
 #undef LIB_SPEC
 #define LIB_SPEC \
   "%{!symbolic:\
-     %{pthreads|pthread:-lpthread} \
      %{p|pg:-ldl} -lc}"
 
 #ifndef CROSS_DIRECTORY_STRUCTURE

--- a/gcc/config/sol2.h
+++ b/gcc/config/sol2.h
@@ -201,8 +201,14 @@ along with GCC; see the file COPYING3.  If not see
 #undef STARTFILE_ARCH_SPEC
 #define STARTFILE_ARCH_SPEC \
   "%{!shared:%{!symbolic: \
-     %{ansi|std=c*|std=iso9899\\:199409:values-Xc.o%s; :values-Xa.o%s} \
-     %{std=c90|std=gnu90:values-xpg4.o%s; :values-xpg6.o%s}}}"
+     %{ \
+	std=c89|std=c90|std=gnu89|std=gnu90:values-Xa.o%s; \
+	ansi|std=c*|std=iso9899\\:199409:values-Xc.o%s; \
+	:values-Xa.o%s} \
+     %{ \
+	std=c89|std=c90|std=gnu89|std=gnu90:; \
+	:values-xpg6.o%s \
+     }}}"
 
 #if defined(HAVE_LD_PIE) && defined(HAVE_SOLARIS_CRTS)
 #define STARTFILE_CRTBEGIN_SPEC "%{static:crtbegin.o%s; \

--- a/gcc/config/sol2.h
+++ b/gcc/config/sol2.h
@@ -210,7 +210,7 @@ along with GCC; see the file COPYING3.  If not see
 				   shared|" PIE_SPEC ":crtbeginS.o%s; \
 				   :crtbegin.o%s}"
 #else
-#define STARTFILE_CRTBEGIN_SPEC	"crtbegin.o%s"
+#define STARTFILE_CRTBEGIN_SPEC	"%{shared:crtbeginS.o%s;:crtbegin.o%s}"
 #endif
 
 #if ENABLE_VTABLE_VERIFY
@@ -290,7 +290,7 @@ along with GCC; see the file COPYING3.  If not see
 			       shared|" PIE_SPEC ":crtendS.o%s; \
 			       :crtend.o%s}"
 #else
-#define ENDFILE_CRTEND_SPEC "crtend.o%s"
+#define ENDFILE_CRTEND_SPEC "%{shared:crtendS.o%s;:crtend.o%s}"
 #endif
 
 #undef  ENDFILE_SPEC

--- a/gcc/config/sol2.h
+++ b/gcc/config/sol2.h
@@ -200,7 +200,7 @@ along with GCC; see the file COPYING3.  If not see
    executable programs.  */
 #undef STARTFILE_ARCH_SPEC
 #define STARTFILE_ARCH_SPEC \
-  "%{!shared:%{!symbolic: \
+  "%{!shared:%{!symbolic:%{!G: \
      %{ \
 	std=c89|std=c90|std=gnu89|std=gnu90:values-Xa.o%s; \
 	ansi|std=c*|std=iso9899\\:199409:values-Xc.o%s; \
@@ -208,14 +208,14 @@ along with GCC; see the file COPYING3.  If not see
      %{ \
 	std=c89|std=c90|std=gnu89|std=gnu90:; \
 	:values-xpg6.o%s \
-     }}}"
+     }}}}"
 
 #if defined(HAVE_LD_PIE) && defined(HAVE_SOLARIS_CRTS)
 #define STARTFILE_CRTBEGIN_SPEC "%{static:crtbegin.o%s; \
-				   shared|" PIE_SPEC ":crtbeginS.o%s; \
+				   shared|G|" PIE_SPEC ":crtbeginS.o%s; \
 				   :crtbegin.o%s}"
 #else
-#define STARTFILE_CRTBEGIN_SPEC	"%{shared:crtbeginS.o%s;:crtbegin.o%s}"
+#define STARTFILE_CRTBEGIN_SPEC	"%{shared|G:crtbeginS.o%s;:crtbegin.o%s}"
 #endif
 
 #if ENABLE_VTABLE_VERIFY
@@ -258,10 +258,10 @@ along with GCC; see the file COPYING3.  If not see
 #endif
 
 #define LIBASAN_EARLY_SPEC ASAN_REJECT_SPEC \
-  " %{!shared:libasan_preinit%O%s} \
-    %{static-libasan:%{!shared: -Bstatic "\
+  " %{!shared:%{!G:libasan_preinit%O%s}} \
+    %{static-libasan:%{!shared:%{!G: -Bstatic "\
     LD_WHOLE_ARCHIVE_OPTION " -lasan " LD_NO_WHOLE_ARCHIVE_OPTION \
-    "-Bdynamic}}%{!static-libasan:-lasan}"
+    "-Bdynamic}}}%{!static-libasan:-lasan}"
 
 /* Error out on -fsanitize=thread|leak.  */
 #define LIBTSAN_EARLY_SPEC "\
@@ -274,28 +274,28 @@ along with GCC; see the file COPYING3.  If not see
 #ifdef HAVE_SOLARIS_CRTS
 /* Since Solaris 11.4, the OS delivers crt1.o, crti.o, and crtn.o, with a hook
    for compiler-dependent stuff like profile handling.  */
-#define STARTFILE_SPEC "%{!shared:%{!symbolic: \
+#define STARTFILE_SPEC "%{!shared:%{!symbolic:%{!G: \
 			  crt1.o%s \
 			  %{p:%e-p is not supported; \
 			    pg:crtpg.o%s gmon.o%s; \
-			      :crtp.o%s}}} \
+			      :crtp.o%s}}}} \
 			crti.o%s %(startfile_arch) %(startfile_crtbegin) \
 			%(startfile_vtv)"
 #else
-#define STARTFILE_SPEC "%{!shared:%{!symbolic: \
+#define STARTFILE_SPEC "%{!shared:%{!symbolic:%{!G: \
 			  %{p:mcrt1.o%s; \
                             pg:gcrt1.o%s gmon.o%s; \
-                              :crt1.o%s}}} \
+                              :crt1.o%s}}}} \
 			crti.o%s %(startfile_arch) %(startfile_crtbegin) \
 			%(startfile_vtv)"
 #endif
 
 #if defined(HAVE_LD_PIE) && defined(HAVE_SOLARIS_CRTS)
 #define ENDFILE_CRTEND_SPEC "%{static:crtend.o%s; \
-			       shared|" PIE_SPEC ":crtendS.o%s; \
+			       shared|G|" PIE_SPEC ":crtendS.o%s; \
 			       :crtend.o%s}"
 #else
-#define ENDFILE_CRTEND_SPEC "%{shared:crtendS.o%s;:crtend.o%s}"
+#define ENDFILE_CRTEND_SPEC "%{shared|G:crtendS.o%s;:crtend.o%s}"
 #endif
 
 #undef  ENDFILE_SPEC
@@ -305,8 +305,7 @@ along with GCC; see the file COPYING3.  If not see
 
 #undef LINK_ARCH32_SPEC_BASE
 #define LINK_ARCH32_SPEC_BASE \
-  "%{G:-G} \
-   %{YP,*} \
+  "%{YP,*} \
    %{R*} \
    %{!YP,*:%{p|pg:-Y P,%R/usr/lib/libp%R/lib:%R/usr/lib} \
 	   %{!p:%{!pg:-Y P,%R/lib:%R/usr/lib}}}"
@@ -318,8 +317,7 @@ along with GCC; see the file COPYING3.  If not see
    ARCH64_SUBDIR appended to the paths.  */
 #undef LINK_ARCH64_SPEC_BASE
 #define LINK_ARCH64_SPEC_BASE \
-  "%{G:-G} \
-   %{YP,*} \
+  "%{YP,*} \
    %{R*} \
    %{!YP,*:%{p|pg:-Y P,%R/usr/lib/libp/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR "}	\
 	   %{!p:%{!pg:-Y P,%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR "}}}"
@@ -405,7 +403,7 @@ along with GCC; see the file COPYING3.  If not see
 #if !defined(USE_GLD) && defined(ENABLE_SHARED_LIBGCC)
 /* With Sun ld, use mapfile to enforce direct binding to libgcc_s unwinder.  */
 #define LINK_LIBGCC_MAPFILE_SPEC \
-  "%{shared|shared-libgcc:-M %slibgcc-unwind.map}"
+  "%{shared|shared-libgcc|G:-M %slibgcc-unwind.map}"
 #else
 /* GNU ld doesn't support direct binding.  */
 #define LINK_LIBGCC_MAPFILE_SPEC ""
@@ -422,9 +420,9 @@ along with GCC; see the file COPYING3.  If not see
 #undef  LINK_SPEC
 #define LINK_SPEC \
   "%{h*} %{v:-V} \
-   %{!shared:%{!static:%{rdynamic: " RDYNAMIC_SPEC "}}} \
+   %{!shared:%{!static:%{!G:%{rdynamic: " RDYNAMIC_SPEC "}}}} \
    %{static:-dn -Bstatic} \
-   %{shared:-G -dy %{!mimpure-text:-z text}} " \
+   %{shared|G:-G -dy %{!mimpure-text:-z text}} " \
    LINK_LIBGCC_MAPFILE_SPEC LINK_CLEARCAP_SPEC " \
    %{symbolic:-Bsymbolic -G -dy -z text} \
    %(link_arch) \

--- a/gcc/configure
+++ b/gcc/configure
@@ -23064,11 +23064,12 @@ if test $in_tree_ld != yes ; then
 	# numbers can be used in ld.so.1 feature checks even if a different
 	# linker is configured.
 	ld_ver=`$gcc_cv_ld -V 2>&1`
-	if echo "$ld_ver" | grep 'Solaris Link Editors' > /dev/null; then
-	  ld_vers=`echo $ld_ver | sed -n \
-	    -e 's,^.*: 5\.[0-9][0-9]*-\([0-9]\.[0-9][0-9]*\).*$,\1,p'`
+	if echo "$ld_ver" | $EGREP 'Solaris Link Editors|Solaris ELF Utilities' > /dev/null; then
+	  ld_vers=`echo $ld_ver | /bin/sed -n \
+	    -E 's,^.*: (5|1[0-9])\.[0-9][0-9]*-([0-9]\.[0-9][0-9]*).*$,\2,p'`
 	  ld_vers_major=`expr "$ld_vers" : '\([0-9]*\)'`
 	  ld_vers_minor=`expr "$ld_vers" : '[0-9]*\.\([0-9]*\)'`
+	  ld_vers_isillumos=`echo "$ld_ver" | grep '(illumos)'`
 	fi
 	;;
     esac
@@ -28337,6 +28338,8 @@ elif test x$gcc_cv_ld != x; then
       *-*-solaris2*)
         # Sun ld has various bugs in .eh_frame_hdr support before version 1.2251.
         if test "$ld_vers_major" -gt 1 || test "$ld_vers_minor" -ge 2251; then
+          gcc_cv_ld_eh_frame_hdr=yes
+        elif test "$ld_vers_minor" -ge 1735 && test -n "$ld_vers_isillumos"; then
           gcc_cv_ld_eh_frame_hdr=yes
         fi
         ;;

--- a/gcc/configure.ac
+++ b/gcc/configure.ac
@@ -2677,11 +2677,12 @@ if test $in_tree_ld != yes ; then
 	# numbers can be used in ld.so.1 feature checks even if a different
 	# linker is configured.
 	ld_ver=`$gcc_cv_ld -V 2>&1`
-	if echo "$ld_ver" | grep 'Solaris Link Editors' > /dev/null; then
-	  ld_vers=`echo $ld_ver | sed -n \
-	    -e 's,^.*: 5\.[0-9][0-9]*-\([0-9]\.[0-9][0-9]*\).*$,\1,p'`
+	if echo "$ld_ver" | $EGREP 'Solaris Link Editors|Solaris ELF Utilities' > /dev/null; then
+	  ld_vers=`echo $ld_ver | /bin/sed -n \
+	    -E 's,^.*: (5|1[0-9])\.[0-9][0-9]*-([0-9]\.[0-9][0-9]*).*$,\2,p'`
 	  ld_vers_major=`expr "$ld_vers" : '\([0-9]*\)'`
 	  ld_vers_minor=`expr "$ld_vers" : '[0-9]*\.\([0-9]*\)'`
+	  ld_vers_isillumos=`echo "$ld_ver" | grep '(illumos)'`
 	fi
 	;;
     esac
@@ -5161,6 +5162,8 @@ elif test x$gcc_cv_ld != x; then
       *-*-solaris2*)
         # Sun ld has various bugs in .eh_frame_hdr support before version 1.2251.
         if test "$ld_vers_major" -gt 1 || test "$ld_vers_minor" -ge 2251; then
+          gcc_cv_ld_eh_frame_hdr=yes
+        elif test "$ld_vers_minor" -ge 1735 && test -n "$ld_vers_isillumos"; then
           gcc_cv_ld_eh_frame_hdr=yes
         fi
         ;;

--- a/gcc/doc/invoke.texi
+++ b/gcc/doc/invoke.texi
@@ -15663,6 +15663,10 @@ dynamically linked.  This is the default code model.
 Generate code for the large code model.  This makes no assumptions about
 addresses and sizes of sections.  Programs can be statically linked only.
 
+@item -msave-args
+@opindex msave-args
+Save integer-sized arguments on the stack on function entry.
+
 @item -mstrict-align
 @itemx -mno-strict-align
 @opindex mstrict-align

--- a/gcc/doc/invoke.texi
+++ b/gcc/doc/invoke.texi
@@ -5695,6 +5695,12 @@ with multiple statement cases using flow-sensitive points-to information.
 Only warns when the converted pointer is dereferenced.
 Does not warn about incomplete types.
 
+@item -fstrict-calling-conventions
+@opindex fstrict-calling-conventions
+Use strict ABI calling conventions even with local functions.
+This disable certain optimizations that may cause GCC to call local
+functions in a manner other than that described by the ABI.
+
 @item -Wstrict-overflow
 @itemx -Wstrict-overflow=@var{n}
 @opindex Wstrict-overflow

--- a/gcc/doc/invoke.texi
+++ b/gcc/doc/invoke.texi
@@ -403,7 +403,7 @@ Objective-C and Objective-C++ Dialects}.
 -fauto-inc-dec  -fbranch-probabilities @gol
 -fbranch-target-load-optimize  -fbranch-target-load-optimize2 @gol
 -fbtr-bb-exclusive  -fcaller-saves @gol
--fcombine-stack-adjustments  -fconserve-stack @gol
+-fclone-functions -fcombine-stack-adjustments  -fconserve-stack @gol
 -fcompare-elim  -fcprop-registers  -fcrossjumping @gol
 -fcse-follow-jumps  -fcse-skip-blocks  -fcx-fortran-rules @gol
 -fcx-limited-range @gol
@@ -9213,6 +9213,15 @@ Tracks stack adjustments (pushes and pops) and stack memory references
 and then tries to find ways to combine them.
 
 Enabled by default at @option{-O1} and higher.
+
+@item -fno-clone-functions
+@opindex fno-clone-functions
+Forbid the implicit cloning of functions implicit in certain
+optimizations.  This also effectively will disable any optimization
+which wishes to clone functions, equivalent to each function having
+the ``noclone'' attribute.  This allows the prevention of the
+dissociation of a piece of text from an intelligible and expected
+symbol name, which may hamper debugging and tracing.
 
 @item -fipa-ra
 @opindex fipa-ra

--- a/gcc/dwarf2out.c
+++ b/gcc/dwarf2out.c
@@ -23400,6 +23400,11 @@ gen_subprogram_die (tree decl, dw_die_ref context_die)
     /* Add the calling convention attribute if requested.  */
     add_calling_convention_attribute (subr_die, decl);
 
+#ifdef TARGET_SAVE_ARGS
+  if (TARGET_SAVE_ARGS)
+    add_AT_flag (subr_die, DW_AT_SUN_amd64_parmdump, 1);
+#endif
+
   /* Output Dwarf info for all of the stuff within the body of the function
      (if it has one - it may be just a declaration).
 

--- a/gcc/gcc-ar.c
+++ b/gcc/gcc-ar.c
@@ -190,12 +190,12 @@ main (int ac, char **av)
 #endif
 
   /* Find the wrapped binutils program.  */
-  exe_name = find_a_file (&target_path, PERSONALITY, X_OK);
+  exe_name = find_a_file (&target_path, "g" PERSONALITY, X_OK);
   if (!exe_name)
     {
-      const char *real_exe_name = PERSONALITY;
+      const char *real_exe_name = "g" PERSONALITY;
 #ifdef CROSS_DIRECTORY_STRUCTURE
-      real_exe_name = concat (target_machine, "-", PERSONALITY, NULL);
+      real_exe_name = concat (target_machine, "-", "g" PERSONALITY, NULL);
 #endif
       exe_name = find_a_file (&path, real_exe_name, X_OK);
       if (!exe_name)

--- a/gcc/intl.c
+++ b/gcc/intl.c
@@ -74,17 +74,11 @@ gcc_init_libintl (void)
 
   if (!strcmp (open_quote, "`") && !strcmp (close_quote, "'"))
     {
-      /* Untranslated quotes that it may be possible to replace with
-	 U+2018 and U+2019; but otherwise use "'" instead of "`" as
-	 opening quote.  */
+      /*
+       * open_quote is ` purely for ease of translation.  If they aren't
+       * translated, use ' for both
+       */
       open_quote = "'";
-#if defined HAVE_LANGINFO_CODESET
-      if (locale_utf8)
-	{
-	  open_quote = "\xe2\x80\x98";
-	  close_quote = "\xe2\x80\x99";
-	}
-#endif
     }
 }
 
@@ -145,6 +139,3 @@ get_spaces (const char *str)
    spaces[len] = '\0';
    return spaces;
 }
-
-
-

--- a/gcc/opts.c
+++ b/gcc/opts.c
@@ -454,7 +454,7 @@ static const struct default_options default_options_table[] =
     { OPT_LEVELS_1_PLUS, OPT_fipa_reference, NULL, 1 },
     { OPT_LEVELS_1_PLUS, OPT_fipa_reference_addressable, NULL, 1 },
     { OPT_LEVELS_1_PLUS, OPT_fmerge_constants, NULL, 1 },
-    { OPT_LEVELS_1_PLUS, OPT_fomit_frame_pointer, NULL, 1 },
+    { OPT_LEVELS_1_PLUS, OPT_fomit_frame_pointer, NULL, 0 },
     { OPT_LEVELS_1_PLUS, OPT_freorder_blocks, NULL, 1 },
     { OPT_LEVELS_1_PLUS, OPT_fshrink_wrap, NULL, 1 },
     { OPT_LEVELS_1_PLUS, OPT_fsplit_wide_types, NULL, 1 },
@@ -484,6 +484,7 @@ static const struct default_options default_options_table[] =
     { OPT_LEVELS_1_PLUS_NOT_DEBUG, OPT_ftree_bit_ccp, NULL, 1 },
     { OPT_LEVELS_1_PLUS_NOT_DEBUG, OPT_ftree_sra, NULL, 1 },
     { OPT_LEVELS_1_PLUS_NOT_DEBUG, OPT_ftree_pta, NULL, 1 },
+
 
     /* -O2 and -Os optimizations.  */
     { OPT_LEVELS_2_PLUS, OPT_fcaller_saves, NULL, 1 },

--- a/gcc/testsuite/gcc.dg/fno-clone-preserves-unused-args.c
+++ b/gcc/testsuite/gcc.dg/fno-clone-preserves-unused-args.c
@@ -1,0 +1,28 @@
+/* { dg-do compile { target { ilp32 } } } */
+/* { dg-options "-O2 -funit-at-a-time -fipa-sra -fno-clone-functions"  } */
+/* { dg-final { scan-assembler "pushl.*\\\$1" } } */
+/* { dg-final { scan-assembler "pushl.*\\\$2" } } */
+/* { dg-final { scan-assembler "pushl.*\\\$3" } } */
+/* { dg-final { scan-assembler "pushl.*\\\$4" } } */
+/* { dg-final { scan-assembler "pushl.*\\\$5" } } */
+
+#include <stdio.h>
+
+/*
+ * Verify that preventing function cloning prevents constant prop/scalar
+ * reduction removing parameters
+ */
+static void
+t(int, int, int, int, int) __attribute__ ((noinline));
+
+int foo()
+{
+    t(1, 2, 3, 4, 5);
+}
+
+/* Only use 3 params, bait constprop/sra into deleting the other two */
+static void
+t(int a, int b, int c, int d, int e)
+{
+    printf("%d %d\n", a, b, c);
+}

--- a/gcc/testsuite/gcc.dg/rtl/x86_64/pro_and_epilogue.c
+++ b/gcc/testsuite/gcc.dg/rtl/x86_64/pro_and_epilogue.c
@@ -1,5 +1,6 @@
 /* { dg-do compile { target { { i?86-*-* x86_64-*-* } && lp64 } } } */
 /* { dg-options "-fdump-rtl-pro_and_epilogue" } */
+/* { dg-skip-if "RTL in test doesn't save arguments" { *-*-* } "-msave-args" "" } */
 
 /* Lightly-modified dump of test.c.274r.split2 for x86_64.  */
 
@@ -95,7 +96,7 @@ int __RTL (startwith ("pro_and_epilogue")) test_1 (int i, int j, int k)
     (cnote 31 NOTE_INSN_DELETED)
   ) ;; insn-chain
   (crtl
-    (return_rtx 
+    (return_rtx
       (reg/i:SI ax)
     ) ;; return_rtx
   ) ;; crtl
@@ -107,4 +108,3 @@ int __RTL (startwith ("pro_and_epilogue")) test_1 (int i, int j, int k)
 
 /* We expect a jump_insn to "simple_return".  */
 /* { dg-final { scan-rtl-dump-times "simple_return" 2 "pro_and_epilogue" } }  */
-

--- a/gcc/testsuite/gcc.target/i386/local.c
+++ b/gcc/testsuite/gcc.target/i386/local.c
@@ -1,5 +1,6 @@
 /* { dg-do compile } */
-/* { dg-options "-O2 -funit-at-a-time" } */
+/* { dg-options "-O2 -funit-at-a-time -fno-strict-calling-conventions" { target ia32 } } */
+/* { dg-options "-O2 -funit-at-a-time" { target lp64 } } */
 /* { dg-final { scan-assembler "magic\[^\\n\]*eax" { target ia32 } } } */
 /* { dg-final { scan-assembler "magic\[^\\n\]*(edi|ecx)" { target { ! ia32 } } } } */
 

--- a/gcc/testsuite/gcc.target/i386/msave-args-mov.c
+++ b/gcc/testsuite/gcc.target/i386/msave-args-mov.c
@@ -1,0 +1,26 @@
+/* { dg-do run { target { { i?86-*-solaris2.* } && lp64 } } } */
+/* { dg-options "-msave-args -mforce-save-regs-using-mov -save-temps" } */
+
+#include <stdio.h>
+
+void t(int, int, int, int, int) __attribute__ ((noinline));
+
+int
+main(int argc, char **argv)
+{
+	t(1, 2, 3, 4, 5);
+	return (0);
+}
+
+void
+t(int a, int b, int c, int d, int e)
+{
+	printf("%d %d %d %d %d", a, b, c, d, e);
+}
+
+/* { dg-final { scan-assembler "movq\t%rdi, -8\\(%rbp\\)" } } */
+/* { dg-final { scan-assembler "movq\t%rsi, -16\\(%rbp\\)" } } */
+/* { dg-final { scan-assembler "movq\t%rdx, -24\\(%rbp\\)" } } */
+/* { dg-final { scan-assembler "movq\t%rcx, -32\\(%rbp\\)" } } */
+/* { dg-final { scan-assembler "movq\t%r8, -40\\(%rbp\\)" } } */
+/* { dg-final { cleanup-saved-temps } } */

--- a/gcc/testsuite/gcc.target/i386/msave-args-push.c
+++ b/gcc/testsuite/gcc.target/i386/msave-args-push.c
@@ -1,0 +1,26 @@
+/* { dg-do run { target { { i?86-*-solaris2.* } && lp64 } } } */
+/* { dg-options "-msave-args -save-temps " } */
+
+#include <stdio.h>
+
+void t(int, int, int, int, int) __attribute__ ((noinline));
+
+int
+main(int argc, char **argv)
+{
+	t(1, 2, 3, 4, 5);
+	return (0);
+}
+
+void
+t(int a, int b, int c, int d, int e)
+{
+	printf("%d %d %d %d %d", a, b, c, d, e);
+}
+
+/* { dg-final { scan-assembler "pushq\t%rdi" } } */
+/* { dg-final { scan-assembler "pushq\t%rsi" } } */
+/* { dg-final { scan-assembler "pushq\t%rdx" } } */
+/* { dg-final { scan-assembler "pushq\t%rcx" } } */
+/* { dg-final { scan-assembler "pushq\t%r8" } } */
+/* { dg-final { cleanup-saved-temps } } */

--- a/gcc/testsuite/gcc.target/i386/pr78691-i386.c
+++ b/gcc/testsuite/gcc.target/i386/pr78691-i386.c
@@ -1,5 +1,6 @@
 /* PR tree-optimization/78691 */
 /* { dg-options "-Os -m16" } */
+/* { dg-skip-if "" { *-*-* } "-msave-args" "" } */
 
 int fn1(char *p1, char *p2) {
   int a;

--- a/gcc/testsuite/gcc.target/i386/pr80569.c
+++ b/gcc/testsuite/gcc.target/i386/pr80569.c
@@ -1,6 +1,7 @@
 /* PR target/80569 */
 /* { dg-do assemble } */
 /* { dg-options "-O2 -m16 -march=haswell" } */
+/* { dg-skip-if "" { *-*-* } "-msave-args" "" } */
 
 void load_kernel(void *setup_addr)
 {

--- a/gcc/testsuite/gcc.target/i386/retarg.c
+++ b/gcc/testsuite/gcc.target/i386/retarg.c
@@ -1,5 +1,6 @@
 /* { dg-do compile { target { ! ia32 } } } */
 /* { dg-options "-O2" } */
+/* { dg-skip-if "" { *-*-* } "-msave-args" "" } */
 
 #include <string.h>
 

--- a/gcc/testsuite/gcc.target/i386/strict-cc.c
+++ b/gcc/testsuite/gcc.target/i386/strict-cc.c
@@ -1,0 +1,24 @@
+/* { dg-do compile { target { ilp32 } } } */
+/* { dg-options "-O2 -funit-at-a-time -fstrict-calling-conventions"  } */
+/* { dg-final { scan-assembler "pushl.*\\\$1" } } */
+/* { dg-final { scan-assembler "pushl.*\\\$2" } } */
+/* { dg-final { scan-assembler "pushl.*\\\$3" } } */
+/* { dg-final { scan-assembler "pushl.*\\\$4" } } */
+/* { dg-final { scan-assembler "pushl.*\\\$5" } } */
+
+#include <stdio.h>
+
+/* Verify that local calling convention is not used if strict conventions.  */
+static int t(int, int, int, int, int) __attribute__ ((noinline));
+
+int
+m()
+{
+    t(1, 2, 3, 4, 5);
+}
+
+static int
+t(int a, int b, int c, int d, int e)
+{
+    printf("%d\n", a, b, c, d, e);
+}

--- a/include/dwarf2.def
+++ b/include/dwarf2.def
@@ -467,6 +467,8 @@ DW_TAG (DW_AT_GNU_denominator, 0x2304)
 /* Biased integer extension.
    See https://gcc.gnu.org/wiki/DW_AT_GNU_bias .  */
 DW_TAG (DW_AT_GNU_bias, 0x2305)
+/* Sun extension. */
+DW_AT (DW_AT_SUN_amd64_parmdump, 0x2224)
 /* UPC extension.  */
 DW_AT (DW_AT_upc_threads_scaled, 0x3210)
 /* PGI (STMicroelectronics) extensions.  */

--- a/libgcc/config.host
+++ b/libgcc/config.host
@@ -277,7 +277,7 @@ case ${host} in
 *-*-solaris2*)
   # Unless linker support and dl_iterate_phdr are present,
   # unwind-dw2-fde-dip.c automatically falls back to unwind-dw2-fde.c.
-  tmake_file="$tmake_file sol2/t-sol2 t-eh-dw2-dip t-crtstuff-pic t-libgcc-pic t-slibgcc t-slibgcc-elf-ver"
+  tmake_file="$tmake_file sol2/t-sol2 t-eh-dw2-dip t-crtstuff-pic t-libgcc-pic t-slibgcc t-slibgcc-elf-ver t-crtstuff-pic"
   if test $with_gnu_ld = yes; then
     tmake_file="$tmake_file t-slibgcc-gld"
   else
@@ -297,6 +297,7 @@ case ${host} in
       i?86-*-solaris2.1[0-9]* | x86_64-*-solaris2.1[0-9]*)
         # Solaris 10+/x86 provides crt1.o, crti.o, crtn.o, and gcrt1.o as
         # part of the base system.
+        extra_parts="$extra_parts crtbeginS.o crtendS.o"
         ;;
       sparc*-*-solaris2.1[0-9]*)
         # Solaris 10+/SPARC lacks crt1.o and gcrt1.o.

--- a/libgo/go/cmd/go/internal/work/gccgo.go
+++ b/libgo/go/cmd/go/internal/work/gccgo.go
@@ -46,7 +46,7 @@ func (gccgoToolchain) linker() string {
 func (gccgoToolchain) ar() string {
 	ar := os.Getenv("AR")
 	if ar == "" {
-		ar = "ar"
+		ar = "/usr/bin/gar"
 	}
 	return ar
 }

--- a/libgo/go/go/internal/gccgoimporter/importer_test.go
+++ b/libgo/go/go/internal/gccgoimporter/importer_test.go
@@ -186,7 +186,7 @@ func TestObjImporter(t *testing.T) {
 
 		runImporterTest(t, imp, initmap, &test)
 
-		cmd = exec.Command("ar", "cr", afile, ofile)
+		cmd = exec.Command("/usr/bin/gar", "cr", afile, ofile)
 		out, err = cmd.CombinedOutput()
 		if err != nil {
 			t.Logf("%s", out)

--- a/libgo/runtime/proc.c
+++ b/libgo/runtime/proc.c
@@ -12,6 +12,10 @@
 #include "config.h"
 
 #ifdef HAVE_DL_ITERATE_PHDR
+#ifdef __sun
+#undef _FILE_OFFSET_BITS
+#define _FILE_OFFSET_BITS 32
+#endif
 #include <link.h>
 #endif
 

--- a/libobjc/Makefile.in
+++ b/libobjc/Makefile.in
@@ -307,14 +307,16 @@ $(srcdir)/configure: @MAINT@ configure.ac $(srcdir)/aclocal.m4
 $(srcdir)/aclocal.m4: @MAINT@ $(aclocal_deps)
 	cd $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
 
-install: install-libs install-headers
+install-strip: INSTALL_STRIP_FLAG = -s
+install install-strip: install-libs install-headers
 
 install-libs: installdirs
 	$(SHELL) $(multi_basedir)/mkinstalldirs $(DESTDIR)$(toolexeclibdir)
-	$(LIBTOOL_INSTALL) $(INSTALL) libobjc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);
+	$(LIBTOOL_INSTALL) $(INSTALL) $(INSTALL_STRIP_FLAG) \
+	  libobjc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);
 	if [ "$(OBJC_BOEHM_GC)" ]; then \
-	  $(LIBTOOL_INSTALL) $(INSTALL) libobjc_gc$(libsuffix).la \
-				$(DESTDIR)$(toolexeclibdir);\
+	  $(LIBTOOL_INSTALL) $(INSTALL) $(INSTALL_STRIP_FLAG) \
+	    libobjc_gc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);\
 	fi
 	$(MULTIDO) $(FLAGS_TO_PASS) multi-do DO="$@"
 	@-$(LIBTOOL) --mode=finish $(DESTDIR)$(toolexeclibdir)
@@ -327,7 +329,7 @@ install-headers:
 	  $(INSTALL_DATA) $${realfile} $(DESTDIR)$(libsubdir)/$(includedirname)/objc; \
 	done
 
-check uninstall install-strip dist installcheck installdirs:
+check uninstall dist installcheck installdirs:
 
 mostlyclean:
 	-$(LIBTOOL_CLEAN) rm -f libobjc$(libsuffix).la libobjc_gc$(libsuffix).la *.lo

--- a/libsanitizer/sanitizer_common/sanitizer_linux.cc
+++ b/libsanitizer/sanitizer_common/sanitizer_linux.cc
@@ -929,7 +929,18 @@ ThreadLister::ThreadLister(pid_t pid) : pid_(pid), buffer_(4096) {
   char task_directory_path[80];
   internal_snprintf(task_directory_path, sizeof(task_directory_path),
                     "/proc/%d/task/", pid);
+#ifdef O_DIRECTORY
   descriptor_ = internal_open(task_directory_path, O_RDONLY | O_DIRECTORY);
+#else
+  struct stat st;
+  stat(task_directory_path, &st);
+  if (S_ISDIR(st.st_mode)) {
+    descriptor_ = internal_open(task_directory_path, O_RDONLY);
+  }
+  else {
+    descriptor_ = (uptr)-1; // Set error value defined in internal_iserror
+  }
+#endif
   if (internal_iserror(descriptor_)) {
     Report("Can't open /proc/%d/task for reading.\n", pid);
   }

--- a/libsanitizer/sanitizer_common/sanitizer_platform_limits_solaris.h
+++ b/libsanitizer/sanitizer_common/sanitizer_platform_limits_solaris.h
@@ -18,6 +18,9 @@
 #include "sanitizer_internal_defs.h"
 #include "sanitizer_platform.h"
 
+struct stat;
+struct dirent;
+
 namespace __sanitizer {
 extern unsigned struct_utsname_sz;
 extern unsigned struct_stat_sz;
@@ -336,6 +339,14 @@ struct __sanitizer_glob_t {
   uptr gl_offs;
   char **gl_pathp;
   int gl_pathn;
+  int gl_matchc;
+  int gl_flags;
+  struct stat **gl_statv;
+  void (*gl_closedir)(void *);
+  struct dirent *(*gl_readdir)(void *);
+  void *(*gl_opendir)(const char *);
+  int (*gl_lstat)(const char *, struct stat *);
+  int (*gl_stat)(const char *, struct stat *);
 };
 
 extern int glob_nomatch;

--- a/libsanitizer/sanitizer_common/sanitizer_posix_libcdep.cc
+++ b/libsanitizer/sanitizer_common/sanitizer_posix_libcdep.cc
@@ -63,13 +63,13 @@ void ReleaseMemoryPagesToOS(uptr beg, uptr end) {
     // In the default Solaris compilation environment, madvise() is declared
     // to take a caddr_t arg; casting it to void * results in an invalid
     // conversion error, so use char * instead.
-    madvise((char *)beg_aligned, end_aligned - beg_aligned,
+    posix_madvise((char *)beg_aligned, end_aligned - beg_aligned,
             SANITIZER_MADVISE_DONTNEED);
 }
 
 bool NoHugePagesInRegion(uptr addr, uptr size) {
 #ifdef MADV_NOHUGEPAGE  // May not be defined on old systems.
-  return madvise((char *)addr, size, MADV_NOHUGEPAGE) == 0;
+  return  posix_madvise((char *)addr, size, MADV_NOHUGEPAGE) == 0;
 #else
   return true;
 #endif  // MADV_NOHUGEPAGE
@@ -77,9 +77,9 @@ bool NoHugePagesInRegion(uptr addr, uptr size) {
 
 bool DontDumpShadowMemory(uptr addr, uptr length) {
 #if defined(MADV_DONTDUMP)
-  return madvise((char *)addr, length, MADV_DONTDUMP) == 0;
+  return posix_madvise((char *)addr, length, MADV_DONTDUMP) == 0;
 #elif defined(MADV_NOCORE)
-  return madvise((char *)addr, length, MADV_NOCORE) == 0;
+  return posix_madvise((char *)addr, length, MADV_NOCORE) == 0;
 #else
   return true;
 #endif  // MADV_DONTDUMP

--- a/libstdc++-v3/acinclude.m4
+++ b/libstdc++-v3/acinclude.m4
@@ -1435,7 +1435,6 @@ AC_DEFUN([GLIBCXX_ENABLE_LIBSTDCXX_TIME], [
         ac_has_nanosleep=yes
         ;;
       solaris*)
-        GLIBCXX_LIBS="$GLIBCXX_LIBS -lrt"
         ac_has_clock_monotonic=yes
         ac_has_clock_realtime=yes
         ac_has_nanosleep=yes

--- a/libstdc++-v3/configure
+++ b/libstdc++-v3/configure
@@ -20880,7 +20880,6 @@ $as_echo "$glibcxx_glibc217" >&6; }
         ac_has_nanosleep=yes
         ;;
       solaris*)
-        GLIBCXX_LIBS="$GLIBCXX_LIBS -lrt"
         ac_has_clock_monotonic=yes
         ac_has_clock_realtime=yes
         ac_has_nanosleep=yes


### PR DESCRIPTION
This is a combination of patches from several sources:
* The[ il-9_1_0 branch](https://github.com/illumos/gcc/commits/il-9_1_0);
* The earlier [il-7_4_0 branch](https://github.com/illumos/gcc/commits/il-7_4_0);
* [OpenIndiana userland](https://github.com/OpenIndiana/oi-userland/tree/oi/hipster/components/developer/gcc-9/patches);
* [OmniOS userland](https://github.com/omniosorg/gcc/commits/ooce-9_2_0);
* [Solaris userland](https://github.com/oracle/solaris-userland/tree/master/components/gcc9/patches);
* [gcc bug 54720](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54720).

Whilst we aren't yet in a position to use this to build all of illumos-gate, we can start testing in the way documented in [IPD 7](https://github.com/illumos/ipd/blob/master/ipd/0007/README.md), and get to a point where distributions are effectively shipping the same gcc 9 compiler.
