### PR TITLE
-G should imply the same specs as -shared

### DIFF
--- a/gcc/config/sol2.h
+++ b/gcc/config/sol2.h
@@ -196,16 +196,16 @@ along with GCC; see the file COPYING3.  If not see
    executable programs.  */
 #undef STARTFILE_ARCH_SPEC
 #define STARTFILE_ARCH_SPEC \
-  "%{!shared:%{!symbolic: \
+  "%{!shared:%{!symbolic:%{!G: \
      %{ansi|std=c*|std=iso9899\\:199409:values-Xc.o%s; :values-Xa.o%s} \
-     %{std=c90|std=gnu90:values-xpg4.o%s; :values-xpg6.o%s}}}"
+     %{std=c90|std=gnu90:values-xpg4.o%s; :values-xpg6.o%s}}}}"
 
 #if defined(HAVE_LD_PIE) && defined(HAVE_SOLARIS_CRTS)
 #define STARTFILE_CRTBEGIN_SPEC "%{static:crtbegin.o%s; \
-				   shared|" PIE_SPEC ":crtbeginS.o%s; \
+				   shared|G|" PIE_SPEC ":crtbeginS.o%s; \
 				   :crtbegin.o%s}"
 #else
-#define STARTFILE_CRTBEGIN_SPEC	"%{shared:crtbeginS.o%s;:crtbegin.o%s}"
+#define STARTFILE_CRTBEGIN_SPEC	"%{shared|G:crtbeginS.o%s;:crtbegin.o%s}"
 #endif
 
 #if ENABLE_VTABLE_VERIFY
@@ -234,28 +234,28 @@ along with GCC; see the file COPYING3.  If not see
 #ifdef HAVE_SOLARIS_CRTS
 /* Since Solaris 11.4, the OS delivers crt1.o, crti.o, and crtn.o, with a hook
    for compiler-dependent stuff like profile handling.  */
-#define STARTFILE_SPEC "%{!shared:%{!symbolic: \
+#define STARTFILE_SPEC "%{!shared:%{!symbolic:%{!G: \
 			  crt1.o%s \
 			  %{p:%e-p is not supported; \
 			    pg:crtpg.o%s gmon.o%s; \
-			      :crtp.o%s}}} \
+			      :crtp.o%s}}}} \
 			crti.o%s %(startfile_arch) %(startfile_crtbegin) \
 			%(startfile_vtv)"
 #else
-#define STARTFILE_SPEC "%{!shared:%{!symbolic: \
+#define STARTFILE_SPEC "%{!shared:%{!symbolic:%{!G: \
 			  %{p:mcrt1.o%s; \
                             pg:gcrt1.o%s gmon.o%s; \
-                              :crt1.o%s}}} \
+                              :crt1.o%s}}}} \
 			crti.o%s %(startfile_arch) %(startfile_crtbegin) \
 			%(startfile_vtv)"
 #endif
 
 #if defined(HAVE_LD_PIE) && defined(HAVE_SOLARIS_CRTS)
 #define ENDFILE_CRTEND_SPEC "%{static:crtend.o%s; \
-			       shared|" PIE_SPEC ":crtendS.o%s; \
+			       shared|G|" PIE_SPEC ":crtendS.o%s; \
 			       :crtend.o%s}"
 #else
-#define ENDFILE_CRTEND_SPEC "%{shared:crtendS.o%s;:crtend.o%s}"
+#define ENDFILE_CRTEND_SPEC "%{shared|G:crtendS.o%s;:crtend.o%s}"
 #endif
 
 #undef  ENDFILE_SPEC
@@ -265,8 +265,7 @@ along with GCC; see the file COPYING3.  If not see
 
 #undef LINK_ARCH32_SPEC_BASE
 #define LINK_ARCH32_SPEC_BASE \
-  "%{G:-G} \
-   %{YP,*} \
+  "%{YP,*} \
    %{R*} \
    %{!YP,*:%{p|pg:-Y P,%R/usr/lib/libp%R/lib:%R/usr/lib} \
 	   %{!p:%{!pg:-Y P,%R/lib:%R/usr/lib}}}"
@@ -278,8 +277,7 @@ along with GCC; see the file COPYING3.  If not see
    ARCH64_SUBDIR appended to the paths.  */
 #undef LINK_ARCH64_SPEC_BASE
 #define LINK_ARCH64_SPEC_BASE \
-  "%{G:-G} \
-   %{YP,*} \
+  "%{YP,*} \
    %{R*} \
    %{!YP,*:%{p|pg:-Y P,%R/usr/lib/libp/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR "}	\
 	   %{!p:%{!pg:-Y P,%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR "}}}"
@@ -365,7 +363,7 @@ along with GCC; see the file COPYING3.  If not see
 #ifndef USE_GLD
 /* With Sun ld, use mapfile to enforce direct binding to libgcc_s unwinder.  */
 #define LINK_LIBGCC_MAPFILE_SPEC \
-  "%{shared|shared-libgcc:-M %slibgcc-unwind.map}"
+  "%{shared|shared-libgcc|G:-M %slibgcc-unwind.map}"
 #else
 /* GNU ld doesn't support direct binding.  */
 #define LINK_LIBGCC_MAPFILE_SPEC ""
@@ -382,9 +380,9 @@ along with GCC; see the file COPYING3.  If not see
 #undef  LINK_SPEC
 #define LINK_SPEC \
   "%{h*} %{v:-V} \
-   %{!shared:%{!static:%{rdynamic: " RDYNAMIC_SPEC "}}} \
+   %{!shared:%{!static:%{!G:%{rdynamic: " RDYNAMIC_SPEC "}}}} \
    %{static:-dn -Bstatic} \
-   %{shared:-G -dy %{!mimpure-text:-z text}} " \
+   %{shared|G:-G -dy %{!mimpure-text:-z text}} " \
    LINK_LIBGCC_MAPFILE_SPEC LINK_CLEARCAP_SPEC " \
    %{symbolic:-Bsymbolic -G -dy -z text} \
    %(link_arch) \


### PR DESCRIPTION
gcc provides a `-G` option which, according to the man page:

>       These additional options are available on System V Release 4 for
>       compatibility with other compilers on those systems:
>
>       -G  Create a shared object.  It is recommended that -symbolic or
>           -shared be used instead.

Unfortunately a lot of software uses -G when it detects illumos and patching `configure.ac` to swap `-G` for `-shared` is a pretty common patch when building software for illumos. An example from pkgsrc:

```
shells/zsh/patches/patch-configure.ac   2020-02-20 11:25:17.244522313 +0000
97:-    solaris*|sysv4*|esix*) DLLDFLAGS="${DLLDFLAGS=-G}" ;;
98:+    solaris*|sysv4*|esix*) DLLDFLAGS="${DLLDFLAGS=-shared}" ;;
```

The problem is that `-G` does not exhibit the same behaviour as either `-shared` or `-symbolic`  and in particular `-G` includes objects such as `crt1.o` in the link line and it should not.

We had a recent regression in OmniOS when building the `zsh` package where it started detecting that the system did not support dynamic linking. Investigation showed that the generation of `crt1.o` had changed with a recent binutils version so that it was using a PC32 relocation for the crt1 call to _start_crt whereas before it was using PLT32. For some reason, the illumos linker silently elided the PLT32 relocation from the final object whereas it retains the PC32 one, and that causes a failure to load a shared object built with -G. This is just background, -G should never have been trying to link in crt1.o

Here are the current differences in the link line between `-G` and `-shared`:

```diff
--- G   2020-02-20 11:25:17.244522313 +0000
+++ shared      2020-02-20 11:25:26.722953119 +0000
@@ -1,6 +1,11 @@
 /opt/gcc-8/libexec/gcc/i386-pc-solaris2.11/8.3.0/collect2
 -V
 -G
+-dy
+-z
+text
+-M
+/opt/gcc-8/lib/gcc/i386-pc-solaris2.11/8.3.0/../../../libgcc-unwind.map
 -Y
 P,/usr/gcc/8/lib/amd64:/lib/amd64:/usr/lib/amd64
 -R
@@ -10,11 +15,9 @@
 -Qy
 -o
 lib.G.so
-/usr/lib/amd64/crt1.o
-/opt/gcc-8/lib/gcc/i386-pc-solaris2.11/8.3.0/amd64/crtp.o
 /usr/lib/amd64/crti.o
 /usr/lib/amd64/values-Xa.o
-/opt/gcc-8/lib/gcc/i386-pc-solaris2.11/8.3.0/amd64/crtbegin.o
+/opt/gcc-8/lib/gcc/i386-pc-solaris2.11/8.3.0/amd64/crtbeginS.o
 -L/opt/gcc-8/lib/gcc/i386-pc-solaris2.11/8.3.0/amd64
 -L/opt/gcc-8/lib/gcc/i386-pc-solaris2.11/8.3.0/../../../amd64
 -L/lib/amd64
@@ -35,5 +38,5 @@
 -lgcc_s
 -z
 record
-/opt/gcc-8/lib/gcc/i386-pc-solaris2.11/8.3.0/amd64/crtend.o
+/opt/gcc-8/lib/gcc/i386-pc-solaris2.11/8.3.0/amd64/crtendS.o
 /usr/lib/amd64/crtn.o
```

This pull request changes `-G` so that behaves in the same way as `-shared`. I've done a complete rebuild of OmniOS userland with a patched version of gcc and there were no build regressions, just an improvement in terms of two packages now building dynamic modules where they did not before (zsh being one of them).