### PR TITLE
13185 -zassert-deflib does not work for 64-bit objects (9.3.0)

### DIFF
--- a/gcc/gcc.c
+++ b/gcc/gcc.c
@@ -7151,15 +7151,34 @@ is_directory (const char *path1, bool linker)
   *cp = '\0';
 
   /* Exclude directories that the linker is known to search.  */
-  if (linker
-      && IS_DIR_SEPARATOR (path[0])
-      && ((cp - path == 6
-	   && filename_ncmp (path + 1, "lib", 3) == 0)
-	  || (cp - path == 10
+  if (linker && IS_DIR_SEPARATOR (path[0])) {
+	size_t len = cp - path;
+
+	if (len >= 6 && filename_ncmp (path + 1, "lib", 3) == 0) {
+		if (len == 6)
+			return 0;
+		if (multilib_os_dir != NULL
+		    && len == 6 + strlen(multilib_os_dir) + 1
+		    && filename_ncmp(path + 5, multilib_os_dir,
+		    strlen(multilib_os_dir)) == 0) {
+			return 0;
+		}
+	}
+
+	if (len >= 10
 	      && filename_ncmp (path + 1, "usr", 3) == 0
 	      && IS_DIR_SEPARATOR (path[4])
-	      && filename_ncmp (path + 5, "lib", 3) == 0)))
-    return 0;
+	      && filename_ncmp (path + 5, "lib", 3) == 0) {
+		if (len == 10)
+			return 0;
+		if (multilib_os_dir != NULL
+		    && len == 10 + strlen(multilib_os_dir) + 1
+		    && filename_ncmp(path + 9, multilib_os_dir,
+		    strlen(multilib_os_dir)) == 0) {
+			return 0;
+		}
+	}
+  }
 
   return (stat (path, &st) >= 0 && S_ISDIR (st.st_mode));
 }


### PR DESCRIPTION
https://www.illumos.org/issues/13185

Using the test case from the above issue, with the fix applied:

```
+ gcc 10, 32
ld: warning: dynamic library found on default search path (/usr/lib): libmtmalloc.so
collect2: error: ld returned 1 exit status

+ gcc 10, 64
ld: warning: dynamic library found on default search path (/usr/lib/amd64): libmtmalloc.so
collect2: error: ld returned 1 exit status
```