### PR TITLE
Il-10.2.0 bring-up

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -574,7 +574,7 @@ STAGEautoprofile_TFLAGS = $(STAGE2_TFLAGS)
 STAGEautofeedback_CFLAGS = $(STAGE3_CFLAGS)
 STAGEautofeedback_TFLAGS = $(STAGE3_TFLAGS)
 
-do-compare = @do_compare@
+do-compare = $(srcdir)/contrib/compare-debug $$f1 $$f2
 do-compare3 = $(do-compare)
 
 # -----------------------------------------------

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+This is the GCC used for compiling illumos.
+
+The `il-*` branches contain the the patches used for building illumos, which
+are rebased versions of those used for Solaris/OpenSolaris, and then
+additional changes.  The versions actually in use are tagged with
+`il-VERSION-ilN` where _N_ version the illumos changes over the GCC version in
+question.
+
+The `wip/*` branches are works in progress and _should never be used_
+
+The `codesourcery/*` and `sun/*` branches contain the original GCCs as patched by
+CodeSourcery and Sun Microsystems for use compiling Solaris and OpenSolaris as
+was, and the GCCFSS patches of Sun's
+
+When building the compilers for illumos use the flags generally used are:
+
+i386
+~~~sh
+../../configure --prefix=/opt/gcc/$VER --with-as=/usr/bin/gas --with-gnu-as \
+   --with-ld=/usr/bin/ld --without-gnu-ld --enable-languages="c,c++,objc" \
+   --enable-shared  --with-mpfr-include=/usr/include/mpfr \
+   --with-gmp-include=/usr/include/gmp \
+   --with-pkgversion="Illumos $(git describe --all)" \
+   --with-bugurl="http://github.com/richlowe/gcc/issues"
+~~~
+
+sparc
+~~~sh
+../../configure --prefix=/opt/gcc/$VER --without-gnu-as --with-as=/usr/ccs/bin/as" \
+   --with-ld=/usr/bin/ld --without-gnu-ld --enable-languages="c,c++,objc" \
+   --enable-shared  --with-mpfr-include=/usr/include/mpfr \
+   --with-gmp-include=/usr/include/gmp \
+   --with-pkgversion="Illumos $(git describe --all)" \
+   --with-bugurl="http://github.com/richlowe/gcc/issues"
+~~~
+
+Please use the correct `--with-bugurl` and `--with-pkgversion` flags as
+appropriate for any modifications you make, but please also be sure that they
+accurately describe what is in use (ie, are not left at the defaults) either.

--- a/contrib/compare_tests
+++ b/contrib/compare_tests
@@ -108,8 +108,15 @@ elif [ -d "$1" -o -d "$2" ] ; then
 	usage "Must specify either two directories or two files"
 fi
 
-sed 's/^XFAIL/FAIL/; s/^ERROR/FAIL/; s/^XPASS/PASS/' < "$1" | awk '/^Running target / {target = $3} { if (target != "unix") { sub(/: /, "&"target": " ); }; print $0; }' | cut -c1-2000 >$tmp1
-sed 's/^XFAIL/FAIL/; s/^ERROR/FAIL/; s/^XPASS/PASS/' < "$2" | awk '/^Running target / {target = $3} { if (target != "unix") { sub(/: /, "&"target": " ); }; print $0; }' | cut -c1-2000 >$tmp2
+osrev=`uname -sr`
+if [ `expr "$osrev" : "SunOS 5."` -eq "8" ]; then
+   AWK=/usr/bin/nawk
+else
+    AWK=awk
+fi
+
+sed 's/^XFAIL/FAIL/; s/^ERROR/FAIL/; s/^XPASS/PASS/' < "$1" | $AWK '/^Running target / {target = $3} { if (target != "unix") { sub(/: /, "&"target": " ); }; print $0; }' | cut -c1-2000 >$tmp1
+sed 's/^XFAIL/FAIL/; s/^ERROR/FAIL/; s/^XPASS/PASS/' < "$2" | $AWK '/^Running target / {target = $3} { if (target != "unix") { sub(/: /, "&"target": " ); }; print $0; }' | cut -c1-2000 >$tmp2
 
 before=$tmp1
 now=$tmp2

--- a/contrib/make_sunver.pl
+++ b/contrib/make_sunver.pl
@@ -55,7 +55,7 @@ foreach $file (@ARGV) {
 # columns.
 
 # The path to elfdump.
-my $elfdump = "/usr/ccs/bin/elfdump";
+my $elfdump = "/usr/bin/elfdump";
 
 if (-f $elfdump) {
     open ELFDUMP,$elfdump.' -s '.(join ' ',@OBJECTS).'|' or die $!;

--- a/fixincludes/fixinc.in
+++ b/fixincludes/fixinc.in
@@ -212,7 +212,7 @@ search_dirs=""
 
 while [ -n "$dirs" ] && [ $levels -gt 0 ]
 do
-  levels=`expr $levels - 1`
+  levels=`expr $levels - 1; true`
   newdirs=
   for d in $dirs
   do
@@ -341,7 +341,7 @@ if $LINKS; then
           cd $LIB
           while [ x$dirname != x ]; do
             component=`echo $dirname | sed -e 's|/.*$||'`
-            mkdir $component >/dev/null 2>&1
+            mkdir -p $component >/dev/null 2>&1
             cd $component
             dirmade=$dirmade/$component
             dirname=`echo $dirname | sed -e 's|[^/]*//*||'`

--- a/gcc/attribs.c
+++ b/gcc/attribs.c
@@ -543,6 +543,15 @@ decl_attributes (tree *node, tree attributes, int flags,
 	attributes = tree_cons (get_identifier ("no_icf"),  NULL, attributes);
     }
 
+  /* If the user passed -fno-clone-functions, all functions should be treated
+     as "noclone" */
+  if (TREE_CODE (*node) == FUNCTION_DECL
+      && !flag_clone_functions)
+    {
+      if (lookup_attribute ("noclone", attributes) == NULL)
+	attributes = tree_cons (get_identifier ("noclone"),  NULL, attributes);
+    }
+
   targetm.insert_attributes (*node, &attributes);
 
   /* Note that attributes on the same declaration are not necessarily

--- a/gcc/common.opt
+++ b/gcc/common.opt
@@ -2598,6 +2598,10 @@ fstrict-aliasing
 Common Report Var(flag_strict_aliasing) Optimization
 Assume strict aliasing rules apply.
 
+fstrict-calling-conventions
+Common Report Var(flag_strict_calling_conventions) Init(1)
+Use strict ABI calling conventions even for static functions
+
 fstrict-overflow
 Common Report
 Treat signed overflow as undefined.  Negated as -fwrapv -fwrapv-pointer.

--- a/gcc/common.opt
+++ b/gcc/common.opt
@@ -1142,6 +1142,11 @@ fcode-hoisting
 Common Report Var(flag_code_hoisting) Optimization
 Enable code hoisting.
 
+fclone-functions
+Common Report Var(flag_clone_functions) Init(1)
+Allow the compiler to clone functions to facilitate certain optimizations.
+Enabled by default.
+
 fcombine-stack-adjustments
 Common Report Var(flag_combine_stack_adjustments) Optimization
 Looks for opportunities to reduce stack adjustments and stack references.

--- a/gcc/config/i386/i386-options.c
+++ b/gcc/config/i386/i386-options.c
@@ -2486,8 +2486,10 @@ ix86_option_override_internal (bool main_args_p,
       &= ~((OPTION_MASK_ISA_BMI | OPTION_MASK_ISA_BMI2 | OPTION_MASK_ISA_TBM)
 	   & ~opts->x_ix86_isa_flags_explicit);
 
-  if (!TARGET_64BIT_P (opts->x_ix86_isa_flags) && TARGET_SAVE_ARGS)
-    error ("-msave-args only works in x32 or 64-bit mode");
+  if (!TARGET_64BIT_P (opts->x_ix86_isa_flags) && TARGET_SAVE_ARGS) {
+    warning (0, "-msave-args only works in x32 or 64-bit mode; ignoring");
+    opts->x_target_flags &= ~MASK_SAVE_ARGS;
+  }
 
   /* Validate -mpreferred-stack-boundary= value or default it to
      PREFERRED_STACK_BOUNDARY_DEFAULT.  */

--- a/gcc/config/i386/i386-options.c
+++ b/gcc/config/i386/i386-options.c
@@ -2487,7 +2487,7 @@ ix86_option_override_internal (bool main_args_p,
 	   & ~opts->x_ix86_isa_flags_explicit);
 
   if (!TARGET_64BIT_P (opts->x_ix86_isa_flags) && TARGET_SAVE_ARGS)
-    error ("-msave-args makes no sense in the 32-bit mode");
+    error ("-msave-args only works in x32 or 64-bit mode");
 
   /* Validate -mpreferred-stack-boundary= value or default it to
      PREFERRED_STACK_BOUNDARY_DEFAULT.  */

--- a/gcc/config/i386/i386-options.c
+++ b/gcc/config/i386/i386-options.c
@@ -2885,6 +2885,15 @@ ix86_option_override_internal (bool main_args_p,
       free (str);
     }
 
+  /*
+   * We never want to omit the frame pointer, regardless of the optimisation
+   * level or options to gcc - we like stack traces too much and it is of
+   * questionable benefit anyway, even on i386.
+   */
+
+  flag_omit_frame_pointer = 0;
+  opts->x_flag_omit_frame_pointer = 0;
+
   /* Save the initial options in case the user does function specific
      options.  */
   if (main_args_p)

--- a/gcc/config/i386/i386-options.c
+++ b/gcc/config/i386/i386-options.c
@@ -2486,6 +2486,9 @@ ix86_option_override_internal (bool main_args_p,
       &= ~((OPTION_MASK_ISA_BMI | OPTION_MASK_ISA_BMI2 | OPTION_MASK_ISA_TBM)
 	   & ~opts->x_ix86_isa_flags_explicit);
 
+  if (!TARGET_64BIT_P (opts->x_ix86_isa_flags) && TARGET_SAVE_ARGS)
+    error ("-msave-args makes no sense in the 32-bit mode");
+
   /* Validate -mpreferred-stack-boundary= value or default it to
      PREFERRED_STACK_BOUNDARY_DEFAULT.  */
   ix86_preferred_stack_boundary = PREFERRED_STACK_BOUNDARY_DEFAULT;

--- a/gcc/config/i386/i386.c
+++ b/gcc/config/i386/i386.c
@@ -416,6 +416,9 @@ static bool i386_asm_output_addr_const_extra (FILE *, rtx);
 static bool ix86_can_inline_p (tree, tree);
 static unsigned int ix86_minimum_incoming_stack_boundary (bool);
 
+static int ix86_nsaved_args (void);
+static rtx_def* pro_epilogue_adjust_stack (rtx, rtx, rtx, int, bool);
+
 
 /* Whether -mtune= or -march= were specified */
 int ix86_tune_defaulted;
@@ -5214,7 +5217,7 @@ ix86_can_use_return_insn_p (void)
 
   struct ix86_frame &frame = cfun->machine->frame;
   return (frame.stack_pointer_offset == UNITS_PER_WORD
-	  && (frame.nregs + frame.nsseregs) == 0);
+	  && (frame.nmsave_args + frame.nregs + frame.nsseregs) == 0);
 }
 
 /* Return stack frame size.  get_frame_size () returns used stack slots
@@ -5249,6 +5252,9 @@ ix86_frame_pointer_required (void)
 
   /* For older 32-bit runtimes setjmp requires valid frame-pointer.  */
   if (TARGET_32BIT_MS_ABI && cfun->calls_setjmp)
+    return true;
+
+  if (TARGET_SAVE_ARGS)
     return true;
 
   /* Win64 SEH, very large frames need a frame-pointer as maximum stack
@@ -6087,6 +6093,7 @@ ix86_compute_frame_layout (void)
 
   frame->nregs = ix86_nsaved_regs ();
   frame->nsseregs = ix86_nsaved_sseregs ();
+  frame->nmsave_args = ix86_nsaved_args ();
 
   /* 64-bit MS ABI seem to require stack alignment to be always 16,
      except for function prologues, leaf functions and when the defult
@@ -6168,7 +6175,8 @@ ix86_compute_frame_layout (void)
     }
 
   frame->save_regs_using_mov
-    = (TARGET_PROLOGUE_USING_MOVE && m->use_fast_prologue_epilogue
+    = ((TARGET_FORCE_SAVE_REGS_USING_MOV ||
+	(TARGET_PROLOGUE_USING_MOVE && m->use_fast_prologue_epilogue))
        /* If static stack checking is enabled and done with probes,
 	  the registers need to be saved before allocating the frame.  */
        && flag_stack_check != STATIC_BUILTIN_STACK_CHECK);
@@ -6187,6 +6195,13 @@ ix86_compute_frame_layout (void)
 
   /* The traditional frame pointer location is at the top of the frame.  */
   frame->hard_frame_pointer_offset = offset;
+
+  if (TARGET_SAVE_ARGS)
+    {
+      offset += frame->nmsave_args * UNITS_PER_WORD;
+      offset += (frame->nmsave_args % 2) * UNITS_PER_WORD;
+    }
+  frame->arg_save_offset = offset;
 
   /* Register save area */
   offset += frame->nregs * UNITS_PER_WORD;
@@ -6326,7 +6341,7 @@ ix86_compute_frame_layout (void)
   /* Size prologue needs to allocate.  */
   to_allocate = offset - frame->sse_reg_save_offset;
 
-  if ((!to_allocate && frame->nregs <= 1)
+  if ((!TARGET_SAVE_ARGS && !to_allocate && frame->nregs <= 1)
       || (TARGET_64BIT && to_allocate >= HOST_WIDE_INT_C (0x80000000))
       /* If stack clash probing needs a loop, then it needs a
 	 scratch register.  But the returned register is only guaranteed
@@ -6345,7 +6360,11 @@ ix86_compute_frame_layout (void)
     {
       frame->red_zone_size = to_allocate;
       if (frame->save_regs_using_mov)
+      {
 	frame->red_zone_size += frame->nregs * UNITS_PER_WORD;
+	frame->red_zone_size += frame->nmsave_args * UNITS_PER_WORD;
+	frame->red_zone_size += (frame->nmsave_args % 2) * UNITS_PER_WORD;
+      }
       if (frame->red_zone_size > RED_ZONE_SIZE - RED_ZONE_RESERVE)
 	frame->red_zone_size = RED_ZONE_SIZE - RED_ZONE_RESERVE;
     }
@@ -6375,6 +6394,22 @@ ix86_compute_frame_layout (void)
 	     frame that is addressable with 8-bit offsets.  */
 	  frame->hard_frame_pointer_offset = frame->stack_pointer_offset - 128;
 	}
+    }
+
+  if (getenv("DEBUG_FRAME_STUFF") != NULL)
+    {
+      printf("nmsave_args: %d\n", frame->nmsave_args);
+      printf("nsseregs: %d\n", frame->nsseregs);
+      printf("nregs: %d\n", frame->nregs);
+
+      printf("frame_pointer_offset: %llx\n", frame->frame_pointer_offset);
+      printf("hard_frame_pointer_offset: %llx\n", frame->hard_frame_pointer_offset);
+      printf("stack_pointer_offset: %llx\n", frame->stack_pointer_offset);
+      printf("hfp_save_offset: %llx\n", frame->hfp_save_offset);
+      printf("arg_save_offset: %llx\n", frame->arg_save_offset);
+      printf("reg_save_offset: %llx\n", frame->reg_save_offset);
+      printf("sse_reg_save_offset: %llx\n", frame->sse_reg_save_offset);
+
     }
 }
 
@@ -6591,6 +6626,23 @@ ix86_emit_save_regs (void)
   unsigned int regno;
   rtx_insn *insn;
 
+  if (TARGET_SAVE_ARGS)
+    {
+      int i;
+      int nsaved = ix86_nsaved_args ();
+      int start = cfun->returns_struct;
+
+      for (i = start; i < start + nsaved; i++)
+	{
+	  regno = x86_64_int_parameter_registers[i];
+	  insn = emit_insn (gen_push (gen_rtx_REG (word_mode, regno)));
+	  RTX_FRAME_RELATED_P (insn) = 1;
+	}
+      if (nsaved % 2 != 0)
+	pro_epilogue_adjust_stack (stack_pointer_rtx, stack_pointer_rtx,
+				   GEN_INT (-UNITS_PER_WORD), -1, false);
+    }
+
   for (regno = FIRST_PSEUDO_REGISTER - 1; regno-- > 0; )
     if (GENERAL_REGNO_P (regno) && ix86_save_reg (regno, true, true))
       {
@@ -6677,9 +6729,30 @@ ix86_emit_save_reg_using_mov (machine_mode mode, unsigned int regno,
 /* Emit code to save registers using MOV insns.
    First register is stored at CFA - CFA_OFFSET.  */
 static void
-ix86_emit_save_regs_using_mov (HOST_WIDE_INT cfa_offset)
+ix86_emit_save_regs_using_mov (const struct ix86_frame *frame)
 {
   unsigned int regno;
+  HOST_WIDE_INT cfa_offset = frame->arg_save_offset;
+
+  if (TARGET_SAVE_ARGS)
+    {
+      int i;
+      int nsaved = ix86_nsaved_args ();
+      int start = cfun->returns_struct;
+
+      /* We deal with this twice? */
+      if (nsaved % 2 != 0)
+	cfa_offset -= UNITS_PER_WORD;
+
+      for (i = start + nsaved - 1; i >= start; i--)
+	{
+	  regno = x86_64_int_parameter_registers[i];
+	  ix86_emit_save_reg_using_mov(word_mode, regno, cfa_offset);
+	  cfa_offset -= UNITS_PER_WORD;
+	}
+    }
+
+  cfa_offset = frame->reg_save_offset;
 
   for (regno = 0; regno < FIRST_PSEUDO_REGISTER; regno++)
     if (GENERAL_REGNO_P (regno) && ix86_save_reg (regno, true, true))
@@ -8158,7 +8231,7 @@ ix86_expand_prologue (void)
 	}
     }
 
-  int_registers_saved = (frame.nregs == 0);
+  int_registers_saved = (frame.nregs == 0 && frame.nmsave_args == 0);
   sse_registers_saved = (frame.nsseregs == 0);
   save_stub_call_needed = (m->call_ms2sysv);
   gcc_assert (sse_registers_saved || !save_stub_call_needed);
@@ -8211,7 +8284,7 @@ ix86_expand_prologue (void)
 	       && (! TARGET_STACK_PROBE
 		   || frame.stack_pointer_offset < CHECK_STACK_LIMIT))
 	{
-	  ix86_emit_save_regs_using_mov (frame.reg_save_offset);
+	  ix86_emit_save_regs_using_mov (&frame);
 	  int_registers_saved = true;
 	}
     }
@@ -8498,7 +8571,7 @@ ix86_expand_prologue (void)
     }
 
   if (!int_registers_saved)
-    ix86_emit_save_regs_using_mov (frame.reg_save_offset);
+    ix86_emit_save_regs_using_mov (&frame);
   if (!sse_registers_saved)
     ix86_emit_save_sse_regs_using_mov (frame.sse_reg_save_offset);
   else if (save_stub_call_needed)
@@ -8533,6 +8606,7 @@ ix86_expand_prologue (void)
      relative to the value of the stack pointer at the end of the function
      prologue, and moving instructions that access redzone area via frame
      pointer inside push sequence violates this assumption.  */
+  /* XXX: We may wish to do this when SAVE_ARGS in general */
   if (frame_pointer_needed && frame.red_zone_size)
     emit_insn (gen_memory_blockage ());
 
@@ -8917,6 +8991,7 @@ ix86_expand_epilogue (int style)
 
   /* See the comment about red zone and frame
      pointer usage in ix86_expand_prologue.  */
+  /* XXX: We may wish to do this when SAVE_ARGS in general */
   if (frame_pointer_needed && frame.red_zone_size)
     emit_insn (gen_memory_blockage ());
 
@@ -9152,6 +9227,35 @@ ix86_expand_epilogue (int style)
 
       ix86_emit_restore_regs_using_pop ();
     }
+
+  if (TARGET_SAVE_ARGS) {
+    /*
+     * For each saved argument, emit a restore note, to make sure it happens
+     * correctly within the shrink wrapping (I think).
+     *
+     * Note that 'restore' in this case merely means the rule is the same as
+     * it was on function entry, not that we have actually done a register
+     * restore (which of course, we haven't).
+     *
+     * If we do not do this, the DWARF code will emit sufficient restores to
+     * provide balance on its own initiative, which in the presence of
+     * -fshrink-wrap may actually _introduce_ unbalance (whereby we only
+     * .cfi_offset a register sometimes, but will always .cfi_restore it.
+     * This will trip an assert.)
+     */
+    int start = cfun->returns_struct;
+    int nsaved = ix86_nsaved_args();
+    int i;
+
+    for (i = start + nsaved - 1; i >= start; i--)
+      queued_cfa_restores
+	= alloc_reg_note (REG_CFA_RESTORE,
+			  gen_rtx_REG(Pmode,
+				      x86_64_int_parameter_registers[i]),
+			  queued_cfa_restores);
+
+    gcc_assert(m->fs.fp_valid);
+  }
 
   /* If we used a stack pointer and haven't already got rid of it,
      then do so now.  */
@@ -10204,6 +10308,18 @@ ix86_cannot_force_const_mem (machine_mode mode, rtx x)
     }
 
   return !ix86_legitimate_constant_p (mode, x);
+}
+
+/* Return number of arguments to be saved on the stack with
+   -msave-args.  */
+
+static int
+ix86_nsaved_args (void)
+{
+  if (TARGET_SAVE_ARGS)
+    return crtl->args.info.regno - cfun->returns_struct;
+  else
+    return 0;
 }
 
 /*  Nonzero if the symbol is marked as dllimport, or as stub-variable,

--- a/gcc/config/i386/i386.c
+++ b/gcc/config/i386/i386.c
@@ -1117,6 +1117,7 @@ ix86_function_regparm (const_tree type, const_tree decl)
 	 and callee not, or vice versa.  Instead look at whether the callee
 	 is optimized or not.  */
       if (target && opt_for_fn (target->decl, optimize)
+	  && !flag_strict_calling_conventions
 	  && !(profile_flag && !flag_fentry))
 	{
 	  if (target->local && target->can_change_signature)
@@ -1213,6 +1214,7 @@ ix86_function_sseregparm (const_tree type, const_tree decl, bool warn)
       /* TARGET_SSE_MATH */
       && (target_opts_for_fn (target->decl)->x_ix86_fpmath & FPMATH_SSE)
       && opt_for_fn (target->decl, optimize)
+      && !flag_strict_calling_conventions
       && !(profile_flag && !flag_fentry))
     {
       if (target->local && target->can_change_signature)

--- a/gcc/config/i386/i386.c
+++ b/gcc/config/i386/i386.c
@@ -5353,7 +5353,9 @@ indirect_thunk_name (char name[32], unsigned int regno,
   if (regno != INVALID_REGNUM && regno != CX_REG && ret_p)
     gcc_unreachable ();
 
-  if (USE_HIDDEN_LINKONCE)
+  if (USE_HIDDEN_LINKONCE ||
+      (cfun && cfun->machine->indirect_branch_type ==
+       indirect_branch_thunk_extern))
     {
       const char *prefix;
 

--- a/gcc/config/i386/i386.c
+++ b/gcc/config/i386/i386.c
@@ -6624,21 +6624,21 @@ static void
 ix86_emit_save_regs (void)
 {
   unsigned int regno;
+  struct ix86_frame &frame = cfun->machine->frame;
   rtx_insn *insn;
 
   if (TARGET_SAVE_ARGS)
     {
       int i;
-      int nsaved = ix86_nsaved_args ();
       int start = cfun->returns_struct;
 
-      for (i = start; i < start + nsaved; i++)
+      for (i = start; i < start + frame.nmsave_args; i++)
 	{
 	  regno = x86_64_int_parameter_registers[i];
 	  insn = emit_insn (gen_push (gen_rtx_REG (word_mode, regno)));
 	  RTX_FRAME_RELATED_P (insn) = 1;
 	}
-      if (nsaved % 2 != 0)
+      if (frame.nmsave_args % 2 != 0)
 	pro_epilogue_adjust_stack (stack_pointer_rtx, stack_pointer_rtx,
 				   GEN_INT (-UNITS_PER_WORD), -1, false);
     }
@@ -6729,22 +6729,21 @@ ix86_emit_save_reg_using_mov (machine_mode mode, unsigned int regno,
 /* Emit code to save registers using MOV insns.
    First register is stored at CFA - CFA_OFFSET.  */
 static void
-ix86_emit_save_regs_using_mov (const struct ix86_frame *frame)
+ix86_emit_save_regs_using_mov (const struct ix86_frame &frame)
 {
   unsigned int regno;
-  HOST_WIDE_INT cfa_offset = frame->arg_save_offset;
+  HOST_WIDE_INT cfa_offset = frame.arg_save_offset;
 
   if (TARGET_SAVE_ARGS)
     {
       int i;
-      int nsaved = ix86_nsaved_args ();
       int start = cfun->returns_struct;
 
       /* We deal with this twice? */
-      if (nsaved % 2 != 0)
+      if (frame.nmsave_args % 2 != 0)
 	cfa_offset -= UNITS_PER_WORD;
 
-      for (i = start + nsaved - 1; i >= start; i--)
+      for (i = start + frame.nmsave_args - 1; i >= start; i--)
 	{
 	  regno = x86_64_int_parameter_registers[i];
 	  ix86_emit_save_reg_using_mov(word_mode, regno, cfa_offset);
@@ -6752,7 +6751,7 @@ ix86_emit_save_regs_using_mov (const struct ix86_frame *frame)
 	}
     }
 
-  cfa_offset = frame->reg_save_offset;
+  cfa_offset = frame.reg_save_offset;
 
   for (regno = 0; regno < FIRST_PSEUDO_REGISTER; regno++)
     if (GENERAL_REGNO_P (regno) && ix86_save_reg (regno, true, true))
@@ -8284,7 +8283,7 @@ ix86_expand_prologue (void)
 	       && (! TARGET_STACK_PROBE
 		   || frame.stack_pointer_offset < CHECK_STACK_LIMIT))
 	{
-	  ix86_emit_save_regs_using_mov (&frame);
+	  ix86_emit_save_regs_using_mov (frame);
 	  int_registers_saved = true;
 	}
     }
@@ -8571,7 +8570,7 @@ ix86_expand_prologue (void)
     }
 
   if (!int_registers_saved)
-    ix86_emit_save_regs_using_mov (&frame);
+    ix86_emit_save_regs_using_mov (frame);
   if (!sse_registers_saved)
     ix86_emit_save_sse_regs_using_mov (frame.sse_reg_save_offset);
   else if (save_stub_call_needed)
@@ -9228,33 +9227,30 @@ ix86_expand_epilogue (int style)
       ix86_emit_restore_regs_using_pop ();
     }
 
-  if (TARGET_SAVE_ARGS) {
-    /*
-     * For each saved argument, emit a restore note, to make sure it happens
-     * correctly within the shrink wrapping (I think).
-     *
-     * Note that 'restore' in this case merely means the rule is the same as
-     * it was on function entry, not that we have actually done a register
-     * restore (which of course, we haven't).
-     *
-     * If we do not do this, the DWARF code will emit sufficient restores to
-     * provide balance on its own initiative, which in the presence of
-     * -fshrink-wrap may actually _introduce_ unbalance (whereby we only
-     * .cfi_offset a register sometimes, but will always .cfi_restore it.
-     * This will trip an assert.)
-     */
-    int start = cfun->returns_struct;
-    int nsaved = ix86_nsaved_args();
-    int i;
+  /*
+   * For each saved argument, emit a restore note, to make sure it happens
+   * correctly within the shrink wrapping (I think).
+   *
+   * Note that 'restore' in this case merely means the rule is the same as
+   * it was on function entry, not that we have actually done a register
+   * restore (which of course, we haven't).
+   *
+   * If we do not do this, the DWARF code will emit sufficient restores to
+   * provide balance on its own initiative, which in the presence of
+   * -fshrink-wrap may actually _introduce_ unbalance (whereby we only
+   * .cfi_offset a register sometimes, but will always .cfi_restore it.
+   * This will trip an assert.)
+   */
+  if (TARGET_SAVE_ARGS && frame.nmsave_args > 0) {
+	  int start = cfun->returns_struct;
+	  int i;
 
-    for (i = start + nsaved - 1; i >= start; i--)
-      queued_cfa_restores
-	= alloc_reg_note (REG_CFA_RESTORE,
+	  for (i = start + frame.nmsave_args - 1; i >= start; i--)
+		  queued_cfa_restores
+		      = alloc_reg_note (REG_CFA_RESTORE,
 			  gen_rtx_REG(Pmode,
-				      x86_64_int_parameter_registers[i]),
+			      x86_64_int_parameter_registers[i]),
 			  queued_cfa_restores);
-
-    gcc_assert(m->fs.fp_valid);
   }
 
   /* If we used a stack pointer and haven't already got rid of it,

--- a/gcc/config/i386/i386.h
+++ b/gcc/config/i386/i386.h
@@ -2618,6 +2618,11 @@ enum avx_u128_state
 
    saved frame pointer			if frame_pointer_needed
 					<- HARD_FRAME_POINTER
+
+   [-msave-args]			<- arg_save_offset
+
+   [saveargs padding]
+
    [saved regs]
 					<- reg_save_offset
    [padding0]
@@ -2651,6 +2656,7 @@ enum avx_u128_state
   */
 struct GTY(()) ix86_frame
 {
+  int nmsave_args;
   int nsseregs;
   int nregs;
   int va_arg_size;
@@ -2662,6 +2668,7 @@ struct GTY(()) ix86_frame
   HOST_WIDE_INT hard_frame_pointer_offset;
   HOST_WIDE_INT stack_pointer_offset;
   HOST_WIDE_INT hfp_save_offset;
+  HOST_WIDE_INT arg_save_offset;
   HOST_WIDE_INT reg_save_offset;
   HOST_WIDE_INT stack_realign_allocate;
   HOST_WIDE_INT stack_realign_offset;

--- a/gcc/config/i386/i386.opt
+++ b/gcc/config/i386/i386.opt
@@ -506,7 +506,7 @@ Use direct references against %gs when accessing tls data.
 
 msave-args
 Target Report Mask(SAVE_ARGS)
-Save integer arguments on the stack at function entry
+Save integer arguments on the stack at function entry.
 
 mforce-save-regs-using-mov
 Target Report Mask(FORCE_SAVE_REGS_USING_MOV)

--- a/gcc/config/i386/i386.opt
+++ b/gcc/config/i386/i386.opt
@@ -504,6 +504,16 @@ mtls-direct-seg-refs
 Target Report Mask(TLS_DIRECT_SEG_REFS)
 Use direct references against %gs when accessing tls data.
 
+msave-args
+Target Report Mask(SAVE_ARGS)
+Save integer arguments on the stack at function entry
+
+mforce-save-regs-using-mov
+Target Report Mask(FORCE_SAVE_REGS_USING_MOV)
+Save registers using push in function prologues.  This is intentionally
+undocumented and used for msave-args testing.
+
+
 mtune=
 Target RejectNegative Negative(mtune=) Joined Var(ix86_tune_string)
 Schedule code for given CPU.

--- a/gcc/config/i386/sol2.h
+++ b/gcc/config/i386/sol2.h
@@ -252,3 +252,20 @@ along with GCC; see the file COPYING3.  If not see
 /* We do not need NT_VERSION notes.  */
 #undef X86_FILE_START_VERSION_DIRECTIVE
 #define X86_FILE_START_VERSION_DIRECTIVE false
+
+/*
+ * As of 5788, the illumos libc includes support for the stack protector
+ * __stack_chk_fail() function and for the __stack_chk_guard variable.
+ * That means that, for most cases, no extra objects need to be linked in
+ * when compiling with one of the -fstack-protector options.
+ * However, for 32-bit PIC/PIE objects, the gcc stack protector emits a
+ * function call to __stack_chk_fail_local(); this symbol is provided in
+ * illumos via the libssp_ns.a object. The spec below includes this in the
+ * link when appropriate.
+ */
+#if defined(TARGET_LIBC_PROVIDES_SSP)
+#define LINK_SSP_SPEC "%{fstack-protector|fstack-protector-all|" \
+		       "fstack-protector-strong|fstack-protector-explicit:" \
+		       DEF_ARCH32_SPEC("-lssp_ns") \
+		       "}"
+#endif

--- a/gcc/config/sol2-c.c
+++ b/gcc/config/sol2-c.c
@@ -67,7 +67,7 @@ static const format_char_info cmn_err_char_table[] =
   { "c",   0, STD_C89, { T89_C,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-w",   "",   NULL },
   { "p",   1, STD_C89, { T89_V,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-w",   "c",  NULL },
   { "s",   1, STD_C89, { T89_C,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-wp",  "cR", NULL },
-  { "b",   0, STD_C89, { T89_I,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-w",   "",   &bitfield_string_type },
+  { "b",   0, STD_C89, { T89_I,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-w0",  "",   &bitfield_string_type },
   { NULL,  0, STD_C89, NOLENGTHS, NULL, NULL, NULL }
 };
 

--- a/gcc/config/sol2-c.c
+++ b/gcc/config/sol2-c.c
@@ -40,7 +40,10 @@ static const format_length_info cmn_err_length_specs[] =
 
 static const format_flag_spec cmn_err_flag_specs[] =
 {
+  { '0',  0, 0, 0, N_("'0' flag"),        N_("the '0' flag"),                     STD_C89 },
+  { '-',  0, 0, 0, N_("'-' flag"),        N_("the '-' flag"),                     STD_C89 },
   { 'w',  0, 0, 0, N_("field width"),     N_("field width in printf format"),     STD_C89 },
+  { 'p',  0, 0, 0, N_("precision"),       N_("precision in printf format"),       STD_C89 },
   { 'L',  0, 0, 0, N_("length modifier"), N_("length modifier in printf format"), STD_C89 },
   { 0, 0, 0, 0, NULL, NULL, STD_C89 }
 };
@@ -48,6 +51,7 @@ static const format_flag_spec cmn_err_flag_specs[] =
 
 static const format_flag_pair cmn_err_flag_pairs[] =
 {
+  { '0', '-', 1, 0 },
   { 0, 0, 0, 0 }
 };
 
@@ -57,21 +61,21 @@ static const format_char_info bitfield_string_type =
 static const format_char_info cmn_err_char_table[] =
 {
   /* C89 conversion specifiers.  */
-  { "dD",  0, STD_C89, { T89_I,   BADLEN,  BADLEN,  T89_L,   T9L_LL,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "w",  "",   NULL },
-  { "oOxX",0, STD_C89, { T89_UI,  BADLEN,  BADLEN,  T89_UL,  T9L_ULL, BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "w",  "",   NULL },
-  { "u",   0, STD_C89, { T89_UI,  BADLEN,  BADLEN,  T89_UL,  T9L_ULL, BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "w",  "",   NULL },
-  { "c",   0, STD_C89, { T89_C,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "w",  "",   NULL },
-  { "p",   1, STD_C89, { T89_V,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "w", "c",  NULL },
-  { "s",   1, STD_C89, { T89_C,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "w",  "cR", NULL },
-  { "b",   0, STD_C89, { T89_I,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "w",   "",   &bitfield_string_type },
+  { "dD",  0, STD_C89, { T89_I,   BADLEN,  BADLEN,  T89_L,   T9L_LL,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-wp0", "",   NULL },
+  { "oOxX",0, STD_C89, { T89_UI,  BADLEN,  BADLEN,  T89_UL,  T9L_ULL, BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-wp0", "",   NULL },
+  { "u",   0, STD_C89, { T89_UI,  BADLEN,  BADLEN,  T89_UL,  T9L_ULL, BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-wp0", "",   NULL },
+  { "c",   0, STD_C89, { T89_C,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-w",   "",   NULL },
+  { "p",   1, STD_C89, { T89_V,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-w",   "c",  NULL },
+  { "s",   1, STD_C89, { T89_C,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-wp",  "cR", NULL },
+  { "b",   0, STD_C89, { T89_I,   BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN,  BADLEN  }, "-w",   "",   &bitfield_string_type },
   { NULL,  0, STD_C89, NOLENGTHS, NULL, NULL, NULL }
 };
 
 EXPORTED_CONST format_kind_info solaris_format_types[] = {
-  { "cmn_err",  cmn_err_length_specs,  cmn_err_char_table, "", NULL,
+  { "cmn_err",  cmn_err_length_specs,  cmn_err_char_table, "0-", NULL,
     cmn_err_flag_specs, cmn_err_flag_pairs,
     FMT_FLAG_ARG_CONVERT|FMT_FLAG_EMPTY_PREC_OK,
-    'w', 0, 0, 0, 'L', 0,
+    'w', 0, 'p', 0, 'L', 0,
     &integer_type_node, &integer_type_node
   }
 };

--- a/gcc/config/sol2.h
+++ b/gcc/config/sol2.h
@@ -161,7 +161,6 @@ along with GCC; see the file COPYING3.  If not see
 #undef LIB_SPEC
 #define LIB_SPEC \
   "%{!symbolic:\
-     %{pthreads|pthread:-lpthread} \
      %{p|pg:-ldl} -lc}"
 
 #ifndef CROSS_DIRECTORY_STRUCTURE

--- a/gcc/config/sol2.h
+++ b/gcc/config/sol2.h
@@ -201,8 +201,14 @@ along with GCC; see the file COPYING3.  If not see
 #undef STARTFILE_ARCH_SPEC
 #define STARTFILE_ARCH_SPEC \
   "%{!shared:%{!symbolic: \
-     %{ansi|std=c*|std=iso9899\\:199409:values-Xc.o%s; :values-Xa.o%s} \
-     %{std=c90|std=gnu90:values-xpg4.o%s; :values-xpg6.o%s}}}"
+     %{ \
+	std=c89|std=c90|std=gnu89|std=gnu90:values-Xa.o%s; \
+	ansi|std=c*|std=iso9899\\:199409:values-Xc.o%s; \
+	:values-Xa.o%s} \
+     %{ \
+	std=c89|std=c90|std=gnu89|std=gnu90:; \
+	:values-xpg6.o%s \
+     }}}"
 
 #if defined(HAVE_LD_PIE) && defined(HAVE_SOLARIS_CRTS)
 #define STARTFILE_CRTBEGIN_SPEC "%{static:crtbegin.o%s; \

--- a/gcc/config/sol2.h
+++ b/gcc/config/sol2.h
@@ -210,7 +210,7 @@ along with GCC; see the file COPYING3.  If not see
 				   shared|" PIE_SPEC ":crtbeginS.o%s; \
 				   :crtbegin.o%s}"
 #else
-#define STARTFILE_CRTBEGIN_SPEC	"crtbegin.o%s"
+#define STARTFILE_CRTBEGIN_SPEC	"%{shared:crtbeginS.o%s;:crtbegin.o%s}"
 #endif
 
 #if ENABLE_VTABLE_VERIFY
@@ -290,7 +290,7 @@ along with GCC; see the file COPYING3.  If not see
 			       shared|" PIE_SPEC ":crtendS.o%s; \
 			       :crtend.o%s}"
 #else
-#define ENDFILE_CRTEND_SPEC "crtend.o%s"
+#define ENDFILE_CRTEND_SPEC "%{shared:crtendS.o%s;:crtend.o%s}"
 #endif
 
 #undef  ENDFILE_SPEC

--- a/gcc/config/sol2.h
+++ b/gcc/config/sol2.h
@@ -200,7 +200,7 @@ along with GCC; see the file COPYING3.  If not see
    executable programs.  */
 #undef STARTFILE_ARCH_SPEC
 #define STARTFILE_ARCH_SPEC \
-  "%{!shared:%{!symbolic: \
+  "%{!shared:%{!symbolic:%{!G: \
      %{ \
 	std=c89|std=c90|std=gnu89|std=gnu90:values-Xa.o%s; \
 	ansi|std=c*|std=iso9899\\:199409:values-Xc.o%s; \
@@ -208,14 +208,14 @@ along with GCC; see the file COPYING3.  If not see
      %{ \
 	std=c89|std=c90|std=gnu89|std=gnu90:; \
 	:values-xpg6.o%s \
-     }}}"
+     }}}}"
 
 #if defined(HAVE_LD_PIE) && defined(HAVE_SOLARIS_CRTS)
 #define STARTFILE_CRTBEGIN_SPEC "%{static:crtbegin.o%s; \
-				   shared|" PIE_SPEC ":crtbeginS.o%s; \
+				   shared|G|" PIE_SPEC ":crtbeginS.o%s; \
 				   :crtbegin.o%s}"
 #else
-#define STARTFILE_CRTBEGIN_SPEC	"%{shared:crtbeginS.o%s;:crtbegin.o%s}"
+#define STARTFILE_CRTBEGIN_SPEC	"%{shared|G:crtbeginS.o%s;:crtbegin.o%s}"
 #endif
 
 #if ENABLE_VTABLE_VERIFY
@@ -258,10 +258,10 @@ along with GCC; see the file COPYING3.  If not see
 #endif
 
 #define LIBASAN_EARLY_SPEC ASAN_REJECT_SPEC \
-  " %{!shared:libasan_preinit%O%s} \
-    %{static-libasan:%{!shared: -Bstatic "\
+  " %{!shared:%{!G:libasan_preinit%O%s}} \
+    %{static-libasan:%{!shared:%{!G: -Bstatic "\
     LD_WHOLE_ARCHIVE_OPTION " -lasan " LD_NO_WHOLE_ARCHIVE_OPTION \
-    "-Bdynamic}}%{!static-libasan:-lasan}"
+    "-Bdynamic}}}%{!static-libasan:-lasan}"
 
 /* Error out on -fsanitize=thread|leak.  */
 #define LIBTSAN_EARLY_SPEC "\
@@ -274,28 +274,28 @@ along with GCC; see the file COPYING3.  If not see
 #ifdef HAVE_SOLARIS_CRTS
 /* Since Solaris 11.4, the OS delivers crt1.o, crti.o, and crtn.o, with a hook
    for compiler-dependent stuff like profile handling.  */
-#define STARTFILE_SPEC "%{!shared:%{!symbolic: \
+#define STARTFILE_SPEC "%{!shared:%{!symbolic:%{!G: \
 			  crt1.o%s \
 			  %{p:%e-p is not supported; \
 			    pg:crtpg.o%s gmon.o%s; \
-			      :crtp.o%s}}} \
+			      :crtp.o%s}}}} \
 			crti.o%s %(startfile_arch) %(startfile_crtbegin) \
 			%(startfile_vtv)"
 #else
-#define STARTFILE_SPEC "%{!shared:%{!symbolic: \
+#define STARTFILE_SPEC "%{!shared:%{!symbolic:%{!G: \
 			  %{p:mcrt1.o%s; \
                             pg:gcrt1.o%s gmon.o%s; \
-                              :crt1.o%s}}} \
+                              :crt1.o%s}}}} \
 			crti.o%s %(startfile_arch) %(startfile_crtbegin) \
 			%(startfile_vtv)"
 #endif
 
 #if defined(HAVE_LD_PIE) && defined(HAVE_SOLARIS_CRTS)
 #define ENDFILE_CRTEND_SPEC "%{static:crtend.o%s; \
-			       shared|" PIE_SPEC ":crtendS.o%s; \
+			       shared|G|" PIE_SPEC ":crtendS.o%s; \
 			       :crtend.o%s}"
 #else
-#define ENDFILE_CRTEND_SPEC "%{shared:crtendS.o%s;:crtend.o%s}"
+#define ENDFILE_CRTEND_SPEC "%{shared|G:crtendS.o%s;:crtend.o%s}"
 #endif
 
 #undef  ENDFILE_SPEC
@@ -305,8 +305,7 @@ along with GCC; see the file COPYING3.  If not see
 
 #undef LINK_ARCH32_SPEC_BASE
 #define LINK_ARCH32_SPEC_BASE \
-  "%{G:-G} \
-   %{YP,*} \
+  "%{YP,*} \
    %{R*} \
    %{!YP,*:%{p|pg:-Y P,%R/usr/lib/libp%R/lib:%R/usr/lib} \
 	   %{!p:%{!pg:-Y P,%R/lib:%R/usr/lib}}}"
@@ -318,8 +317,7 @@ along with GCC; see the file COPYING3.  If not see
    ARCH64_SUBDIR appended to the paths.  */
 #undef LINK_ARCH64_SPEC_BASE
 #define LINK_ARCH64_SPEC_BASE \
-  "%{G:-G} \
-   %{YP,*} \
+  "%{YP,*} \
    %{R*} \
    %{!YP,*:%{p|pg:-Y P,%R/usr/lib/libp/" ARCH64_SUBDIR ":%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR "}	\
 	   %{!p:%{!pg:-Y P,%R/lib/" ARCH64_SUBDIR ":%R/usr/lib/" ARCH64_SUBDIR "}}}"
@@ -405,7 +403,7 @@ along with GCC; see the file COPYING3.  If not see
 #if !defined(USE_GLD) && defined(ENABLE_SHARED_LIBGCC)
 /* With Sun ld, use mapfile to enforce direct binding to libgcc_s unwinder.  */
 #define LINK_LIBGCC_MAPFILE_SPEC \
-  "%{shared|shared-libgcc:-M %slibgcc-unwind.map}"
+  "%{shared|shared-libgcc|G:-M %slibgcc-unwind.map}"
 #else
 /* GNU ld doesn't support direct binding.  */
 #define LINK_LIBGCC_MAPFILE_SPEC ""
@@ -422,9 +420,9 @@ along with GCC; see the file COPYING3.  If not see
 #undef  LINK_SPEC
 #define LINK_SPEC \
   "%{h*} %{v:-V} \
-   %{!shared:%{!static:%{rdynamic: " RDYNAMIC_SPEC "}}} \
+   %{!shared:%{!static:%{!G:%{rdynamic: " RDYNAMIC_SPEC "}}}} \
    %{static:-dn -Bstatic} \
-   %{shared:-G -dy %{!mimpure-text:-z text}} " \
+   %{shared|G:-G -dy %{!mimpure-text:-z text}} " \
    LINK_LIBGCC_MAPFILE_SPEC LINK_CLEARCAP_SPEC " \
    %{symbolic:-Bsymbolic -G -dy -z text} \
    %(link_arch) \

--- a/gcc/configure
+++ b/gcc/configure
@@ -23438,11 +23438,12 @@ if test $in_tree_ld != yes ; then
 	# numbers can be used in ld.so.1 feature checks even if a different
 	# linker is configured.
 	ld_ver=`$gcc_cv_ld -V 2>&1`
-	if echo "$ld_ver" | grep 'Solaris Link Editors' > /dev/null; then
-	  ld_vers=`echo $ld_ver | sed -n \
-	    -e 's,^.*: 5\.[0-9][0-9]*-\([0-9]\.[0-9][0-9]*\).*$,\1,p'`
+	if echo "$ld_ver" | $EGREP 'Solaris Link Editors|Solaris ELF Utilities' > /dev/null; then
+	  ld_vers=`echo $ld_ver | /bin/sed -n \
+	    -E 's,^.*: (5|1[0-9])\.[0-9][0-9]*-([0-9]\.[0-9][0-9]*).*$,\2,p'`
 	  ld_vers_major=`expr "$ld_vers" : '\([0-9]*\)'`
 	  ld_vers_minor=`expr "$ld_vers" : '[0-9]*\.\([0-9]*\)'`
+	  ld_vers_isillumos=`echo "$ld_ver" | grep '(illumos)'`
 	fi
 	;;
     esac
@@ -28825,6 +28826,8 @@ elif test x$gcc_cv_ld != x; then
       *-*-solaris2*)
         # Sun ld has various bugs in .eh_frame_hdr support before version 1.2251.
         if test "$ld_vers_major" -gt 1 || test "$ld_vers_minor" -ge 2251; then
+          gcc_cv_ld_eh_frame_hdr=yes
+        elif test "$ld_vers_minor" -ge 1735 && test -n "$ld_vers_isillumos"; then
           gcc_cv_ld_eh_frame_hdr=yes
         fi
         ;;

--- a/gcc/configure
+++ b/gcc/configure
@@ -29770,7 +29770,7 @@ fi
 	 # realistically usable GNU/Hurd configurations.
 	 # All supported versions of musl provide it as well
 	 gcc_cv_libc_provides_ssp=yes;;
-       *-*-darwin* | *-*-freebsd* | *-*-netbsd*)
+       *-*-darwin* | *-*-freebsd* | *-*-netbsd* | *-*-solaris2*)
 	 ac_fn_cxx_check_func "$LINENO" "__stack_chk_fail" "ac_cv_func___stack_chk_fail"
 if test "x$ac_cv_func___stack_chk_fail" = xyes; then :
   gcc_cv_libc_provides_ssp=yes

--- a/gcc/configure.ac
+++ b/gcc/configure.ac
@@ -2847,11 +2847,12 @@ if test $in_tree_ld != yes ; then
 	# numbers can be used in ld.so.1 feature checks even if a different
 	# linker is configured.
 	ld_ver=`$gcc_cv_ld -V 2>&1`
-	if echo "$ld_ver" | grep 'Solaris Link Editors' > /dev/null; then
-	  ld_vers=`echo $ld_ver | sed -n \
-	    -e 's,^.*: 5\.[0-9][0-9]*-\([0-9]\.[0-9][0-9]*\).*$,\1,p'`
+	if echo "$ld_ver" | $EGREP 'Solaris Link Editors|Solaris ELF Utilities' > /dev/null; then
+	  ld_vers=`echo $ld_ver | /bin/sed -n \
+	    -E 's,^.*: (5|1[0-9])\.[0-9][0-9]*-([0-9]\.[0-9][0-9]*).*$,\2,p'`
 	  ld_vers_major=`expr "$ld_vers" : '\([0-9]*\)'`
 	  ld_vers_minor=`expr "$ld_vers" : '[0-9]*\.\([0-9]*\)'`
+	  ld_vers_isillumos=`echo "$ld_ver" | grep '(illumos)'`
 	fi
 	;;
     esac
@@ -5361,6 +5362,8 @@ elif test x$gcc_cv_ld != x; then
       *-*-solaris2*)
         # Sun ld has various bugs in .eh_frame_hdr support before version 1.2251.
         if test "$ld_vers_major" -gt 1 || test "$ld_vers_minor" -ge 2251; then
+          gcc_cv_ld_eh_frame_hdr=yes
+        elif test "$ld_vers_minor" -ge 1735 && test -n "$ld_vers_isillumos"; then
           gcc_cv_ld_eh_frame_hdr=yes
         fi
         ;;

--- a/gcc/configure.ac
+++ b/gcc/configure.ac
@@ -6165,7 +6165,7 @@ AC_CACHE_CHECK(__stack_chk_fail in target C library,
 	 # realistically usable GNU/Hurd configurations.
 	 # All supported versions of musl provide it as well
 	 gcc_cv_libc_provides_ssp=yes;;
-       *-*-darwin* | *-*-freebsd* | *-*-netbsd*)
+       *-*-darwin* | *-*-freebsd* | *-*-netbsd* | *-*-solaris2*)
 	 AC_CHECK_FUNC(__stack_chk_fail,[gcc_cv_libc_provides_ssp=yes],
            [echo "no __stack_chk_fail on this target"])
         ;;

--- a/gcc/doc/invoke.texi
+++ b/gcc/doc/invoke.texi
@@ -6288,6 +6288,12 @@ with multiple statement cases using flow-sensitive points-to information.
 Only warns when the converted pointer is dereferenced.
 Does not warn about incomplete types.
 
+@item -fstrict-calling-conventions
+@opindex fstrict-calling-conventions
+Use strict ABI calling conventions even with local functions.
+This disable certain optimizations that may cause GCC to call local
+functions in a manner other than that described by the ABI.
+
 @item -Wstrict-overflow
 @itemx -Wstrict-overflow=@var{n}
 @opindex Wstrict-overflow

--- a/gcc/doc/invoke.texi
+++ b/gcc/doc/invoke.texi
@@ -461,6 +461,7 @@ Objective-C and Objective-C++ Dialects}.
 -fassociative-math  -fauto-profile  -fauto-profile[=@var{path}] @gol
 -fauto-inc-dec  -fbranch-probabilities @gol
 -fcaller-saves @gol
+-fclone-functions
 -fcombine-stack-adjustments  -fconserve-stack @gol
 -fcompare-elim  -fcprop-registers  -fcrossjumping @gol
 -fcse-follow-jumps  -fcse-skip-blocks  -fcx-fortran-rules @gol
@@ -10131,6 +10132,15 @@ Tracks stack adjustments (pushes and pops) and stack memory references
 and then tries to find ways to combine them.
 
 Enabled by default at @option{-O1} and higher.
+
+@item -fno-clone-functions
+@opindex fno-clone-functions
+Forbid the implicit cloning of functions implicit in certain
+optimizations.  This also effectively will disable any optimization
+which wishes to clone functions, equivalent to each function having
+the ``noclone'' attribute.  This allows the prevention of the
+dissociation of a piece of text from an intelligible and expected
+symbol name, which may hamper debugging and tracing.
 
 @item -fipa-ra
 @opindex fipa-ra

--- a/gcc/doc/invoke.texi
+++ b/gcc/doc/invoke.texi
@@ -16807,6 +16807,10 @@ addresses and sizes of sections.  Programs can be statically linked only.  The
 @option{-mcmodel=large} option is incompatible with @option{-mabi=ilp32},
 @option{-fpic} and @option{-fPIC}.
 
+@item -msave-args
+@opindex msave-args
+Save integer-sized arguments on the stack on function entry.
+
 @item -mstrict-align
 @itemx -mno-strict-align
 @opindex mstrict-align

--- a/gcc/dwarf2out.c
+++ b/gcc/dwarf2out.c
@@ -23304,6 +23304,11 @@ gen_subprogram_die (tree decl, dw_die_ref context_die)
     /* Add the calling convention attribute if requested.  */
     add_calling_convention_attribute (subr_die, decl);
 
+#ifdef TARGET_SAVE_ARGS
+  if (TARGET_SAVE_ARGS)
+    add_AT_flag (subr_die, DW_AT_SUN_amd64_parmdump, 1);
+#endif
+
   /* Output Dwarf info for all of the stuff within the body of the function
      (if it has one - it may be just a declaration).
 

--- a/gcc/expr.c
+++ b/gcc/expr.c
@@ -11729,12 +11729,12 @@ string_constant (tree arg, tree *ptr_offset, tree *mem_size, tree *decl)
       while (TREE_CODE (chartype) == ARRAY_TYPE)
 	chartype = TREE_TYPE (chartype);
       /* Convert a char array to an empty STRING_CST having an array
-	 of the expected type.  */
+	 of the expected type and size.  */
       if (!initsize)
 	  initsize = integer_zero_node;
 
       unsigned HOST_WIDE_INT size = tree_to_uhwi (initsize);
-      init = build_string_literal (size ? 1 : 0, "", chartype, size);
+      init = build_string_literal (size, NULL, chartype, size);
       init = TREE_OPERAND (init, 0);
       init = TREE_OPERAND (init, 0);
 

--- a/gcc/fold-const.c
+++ b/gcc/fold-const.c
@@ -15421,24 +15421,29 @@ fold_build_pointer_plus_hwi_loc (location_t loc, tree ptr, HOST_WIDE_INT off)
 			  ptr, size_int (off));
 }
 
-/* Return a pointer P to a NUL-terminated string representing the sequence
-   of constant characters referred to by SRC (or a subsequence of such
-   characters within it if SRC is a reference to a string plus some
-   constant offset).  If STRLEN is non-null, store the number of bytes
-   in the string constant including the terminating NUL char.  *STRLEN is
-   typically strlen(P) + 1 in the absence of embedded NUL characters.  */
+/* Return a pointer P to a NUL-terminated string containing the sequence
+   of bytes corresponding to the representation of the object referred to
+   by SRC (or a subsequence of such bytes within it if SRC is a reference
+   to an initialized constant array plus some constant offset).
+   If STRSIZE is non-null, store the number of bytes in the constant
+   sequence including the terminating NUL byte.  *STRSIZE is equal to
+   sizeof(A) - OFFSET where A is the array that stores the constant
+   sequence that SRC points to and OFFSET is the byte offset of SRC from
+   the beginning of A.  SRC need not point to a string or even an array
+   of characters but may point to an object of any type.  */
 
 const char *
-c_getstr (tree src, unsigned HOST_WIDE_INT *strlen /* = NULL */)
+c_getstr (tree src, unsigned HOST_WIDE_INT *strsize /* = NULL */)
 {
+  /* The offset into the array A storing the string, and A's byte size.  */
   tree offset_node;
   tree mem_size;
 
-  if (strlen)
-    *strlen = 0;
+  if (strsize)
+    *strsize = 0;
 
   src = string_constant (src, &offset_node, &mem_size, NULL);
-  if (src == 0)
+  if (!src)
     return NULL;
 
   unsigned HOST_WIDE_INT offset = 0;
@@ -15453,34 +15458,44 @@ c_getstr (tree src, unsigned HOST_WIDE_INT *strlen /* = NULL */)
   if (!tree_fits_uhwi_p (mem_size))
     return NULL;
 
-  /* STRING_LENGTH is the size of the string literal, including any
-     embedded NULs.  STRING_SIZE is the size of the array the string
-     literal is stored in.  */
-  unsigned HOST_WIDE_INT string_length = TREE_STRING_LENGTH (src);
-  unsigned HOST_WIDE_INT string_size = tree_to_uhwi (mem_size);
+  /* ARRAY_SIZE is the byte size of the array the constant sequence
+     is stored in and equal to sizeof A.  INIT_BYTES is the number
+     of bytes in the constant sequence used to initialize the array,
+     including any embedded NULs as well as the terminating NUL (for
+     strings), but not including any trailing zeros/NULs past
+     the terminating one appended implicitly to a string literal to
+     zero out the remainder of the array it's stored in.  For example,
+     given:
+       const char a[7] = "abc\0d";
+       n = strlen (a + 1);
+     ARRAY_SIZE is 7, INIT_BYTES is 6, and OFFSET is 1.  For a valid
+     (i.e., nul-terminated) string with no embedded nuls, INIT_BYTES
+     is equal to strlen (A) + 1.  */
+  const unsigned HOST_WIDE_INT array_size = tree_to_uhwi (mem_size);
+  unsigned HOST_WIDE_INT init_bytes = TREE_STRING_LENGTH (src);
 
   /* Ideally this would turn into a gcc_checking_assert over time.  */
-  if (string_length > string_size)
-    string_length = string_size;
+  if (init_bytes > array_size)
+    init_bytes = array_size;
 
   const char *string = TREE_STRING_POINTER (src);
 
   /* Ideally this would turn into a gcc_checking_assert over time.  */
-  if (string_length > string_size)
-    string_length = string_size;
+  if (init_bytes > array_size)
+    init_bytes = array_size;
 
-  if (string_length == 0
-      || offset >= string_size)
+  if (init_bytes == 0 || offset >= array_size)
     return NULL;
 
-  if (strlen)
+  if (strsize)
     {
-      /* Compute and store the length of the substring at OFFSET.
-	 All offsets past the initial length refer to null strings.  */
-      if (offset < string_length)
-	*strlen = string_length - offset;
+      /* Compute and store the number of characters from the beginning
+	 of the substring at OFFSET to the end, including the terminating
+	 nul.  Offsets past the initial length refer to null strings.  */
+      if (offset < init_bytes)
+	*strsize = init_bytes - offset;
       else
-	*strlen = 1;
+	*strsize = 1;
     }
   else
     {
@@ -15488,11 +15503,11 @@ c_getstr (tree src, unsigned HOST_WIDE_INT *strlen /* = NULL */)
       /* Support only properly NUL-terminated single byte strings.  */
       if (tree_to_uhwi (TYPE_SIZE_UNIT (eltype)) != 1)
 	return NULL;
-      if (string[string_length - 1] != '\0')
+      if (string[init_bytes - 1] != '\0')
 	return NULL;
     }
 
-  return offset < string_length ? string + offset : "";
+  return offset < init_bytes ? string + offset : "";
 }
 
 /* Given a tree T, compute which bits in T may be nonzero.  */

--- a/gcc/gcc-ar.c
+++ b/gcc/gcc-ar.c
@@ -190,12 +190,12 @@ main (int ac, char **av)
 #endif
 
   /* Find the wrapped binutils program.  */
-  exe_name = find_a_file (&target_path, PERSONALITY, X_OK);
+  exe_name = find_a_file (&target_path, "g" PERSONALITY, X_OK);
   if (!exe_name)
     {
-      const char *real_exe_name = PERSONALITY;
+      const char *real_exe_name = "g" PERSONALITY;
 #ifdef CROSS_DIRECTORY_STRUCTURE
-      real_exe_name = concat (target_machine, "-", PERSONALITY, NULL);
+      real_exe_name = concat (target_machine, "-", "g" PERSONALITY, NULL);
 #endif
       exe_name = find_a_file (&path, real_exe_name, X_OK);
       if (!exe_name)

--- a/gcc/gcc.c
+++ b/gcc/gcc.c
@@ -7187,15 +7187,34 @@ is_directory (const char *path1, bool linker)
   *cp = '\0';
 
   /* Exclude directories that the linker is known to search.  */
-  if (linker
-      && IS_DIR_SEPARATOR (path[0])
-      && ((cp - path == 6
-	   && filename_ncmp (path + 1, "lib", 3) == 0)
-	  || (cp - path == 10
+  if (linker && IS_DIR_SEPARATOR (path[0])) {
+	size_t len = cp - path;
+
+	if (len >= 6 && filename_ncmp (path + 1, "lib", 3) == 0) {
+		if (len == 6)
+			return 0;
+		if (multilib_os_dir != NULL
+		    && len == 6 + strlen(multilib_os_dir) + 1
+		    && filename_ncmp(path + 5, multilib_os_dir,
+		    strlen(multilib_os_dir)) == 0) {
+			return 0;
+		}
+	}
+
+	if (len >= 10
 	      && filename_ncmp (path + 1, "usr", 3) == 0
 	      && IS_DIR_SEPARATOR (path[4])
-	      && filename_ncmp (path + 5, "lib", 3) == 0)))
-    return 0;
+	      && filename_ncmp (path + 5, "lib", 3) == 0) {
+		if (len == 10)
+			return 0;
+		if (multilib_os_dir != NULL
+		    && len == 10 + strlen(multilib_os_dir) + 1
+		    && filename_ncmp(path + 9, multilib_os_dir,
+		    strlen(multilib_os_dir)) == 0) {
+			return 0;
+		}
+	}
+  }
 
   return (stat (path, &st) >= 0 && S_ISDIR (st.st_mode));
 }

--- a/gcc/intl.c
+++ b/gcc/intl.c
@@ -74,17 +74,11 @@ gcc_init_libintl (void)
 
   if (!strcmp (open_quote, "`") && !strcmp (close_quote, "'"))
     {
-      /* Untranslated quotes that it may be possible to replace with
-	 U+2018 and U+2019; but otherwise use "'" instead of "`" as
-	 opening quote.  */
+      /*
+       * open_quote is ` purely for ease of translation.  If they aren't
+       * translated, use ' for both
+       */
       open_quote = "'";
-#if defined HAVE_LANGINFO_CODESET
-      if (locale_utf8)
-	{
-	  open_quote = "\xe2\x80\x98";
-	  close_quote = "\xe2\x80\x99";
-	}
-#endif
     }
 }
 
@@ -145,6 +139,3 @@ get_spaces (const char *str)
    spaces[len] = '\0';
    return spaces;
 }
-
-
-

--- a/gcc/opts.c
+++ b/gcc/opts.c
@@ -439,7 +439,7 @@ static const struct default_options default_options_table[] =
     { OPT_LEVELS_1_PLUS, OPT_fipa_reference, NULL, 1 },
     { OPT_LEVELS_1_PLUS, OPT_fipa_reference_addressable, NULL, 1 },
     { OPT_LEVELS_1_PLUS, OPT_fmerge_constants, NULL, 1 },
-    { OPT_LEVELS_1_PLUS, OPT_fomit_frame_pointer, NULL, 1 },
+    { OPT_LEVELS_1_PLUS, OPT_fomit_frame_pointer, NULL, 0 },
     { OPT_LEVELS_1_PLUS, OPT_freorder_blocks, NULL, 1 },
     { OPT_LEVELS_1_PLUS, OPT_fshrink_wrap, NULL, 1 },
     { OPT_LEVELS_1_PLUS, OPT_fsplit_wide_types, NULL, 1 },
@@ -470,6 +470,7 @@ static const struct default_options default_options_table[] =
     { OPT_LEVELS_1_PLUS_NOT_DEBUG, OPT_ftree_dse, NULL, 1 },
     { OPT_LEVELS_1_PLUS_NOT_DEBUG, OPT_ftree_pta, NULL, 1 },
     { OPT_LEVELS_1_PLUS_NOT_DEBUG, OPT_ftree_sra, NULL, 1 },
+
 
     /* -O2 and -Os optimizations.  */
     { OPT_LEVELS_2_PLUS, OPT_fcaller_saves, NULL, 1 },

--- a/gcc/testsuite/gcc.dg/fno-clone-preserves-unused-args.c
+++ b/gcc/testsuite/gcc.dg/fno-clone-preserves-unused-args.c
@@ -1,0 +1,28 @@
+/* { dg-do compile { target { ilp32 } } } */
+/* { dg-options "-O2 -funit-at-a-time -fipa-sra -fno-clone-functions"  } */
+/* { dg-final { scan-assembler "pushl.*\\\$1" } } */
+/* { dg-final { scan-assembler "pushl.*\\\$2" } } */
+/* { dg-final { scan-assembler "pushl.*\\\$3" } } */
+/* { dg-final { scan-assembler "pushl.*\\\$4" } } */
+/* { dg-final { scan-assembler "pushl.*\\\$5" } } */
+
+#include <stdio.h>
+
+/*
+ * Verify that preventing function cloning prevents constant prop/scalar
+ * reduction removing parameters
+ */
+static void
+t(int, int, int, int, int) __attribute__ ((noinline));
+
+int foo()
+{
+    t(1, 2, 3, 4, 5);
+}
+
+/* Only use 3 params, bait constprop/sra into deleting the other two */
+static void
+t(int a, int b, int c, int d, int e)
+{
+    printf("%d %d\n", a, b, c);
+}

--- a/gcc/testsuite/gcc.dg/rtl/x86_64/pro_and_epilogue.c
+++ b/gcc/testsuite/gcc.dg/rtl/x86_64/pro_and_epilogue.c
@@ -1,5 +1,6 @@
 /* { dg-do compile { target { { i?86-*-* x86_64-*-* } && lp64 } } } */
 /* { dg-options "-fdump-rtl-pro_and_epilogue" } */
+/* { dg-skip-if "RTL in test doesn't save arguments" { *-*-* } "-msave-args" "" } */
 
 /* Lightly-modified dump of test.c.274r.split2 for x86_64.  */
 
@@ -95,7 +96,7 @@ int __RTL (startwith ("pro_and_epilogue")) test_1 (int i, int j, int k)
     (cnote 31 NOTE_INSN_DELETED)
   ) ;; insn-chain
   (crtl
-    (return_rtx 
+    (return_rtx
       (reg/i:SI ax)
     ) ;; return_rtx
   ) ;; crtl
@@ -107,4 +108,3 @@ int __RTL (startwith ("pro_and_epilogue")) test_1 (int i, int j, int k)
 
 /* We expect a jump_insn to "simple_return".  */
 /* { dg-final { scan-rtl-dump-times "simple_return" 2 "pro_and_epilogue" } }  */
-

--- a/gcc/testsuite/gcc.target/i386/local.c
+++ b/gcc/testsuite/gcc.target/i386/local.c
@@ -1,5 +1,6 @@
 /* { dg-do compile } */
-/* { dg-options "-O2 -funit-at-a-time" } */
+/* { dg-options "-O2 -funit-at-a-time -fno-strict-calling-conventions" { target ia32 } } */
+/* { dg-options "-O2 -funit-at-a-time" { target lp64 } } */
 /* { dg-final { scan-assembler "magic\[^\\n\]*eax" { target ia32 } } } */
 /* { dg-final { scan-assembler "magic\[^\\n\]*(edi|ecx)" { target { ! ia32 } } } } */
 

--- a/gcc/testsuite/gcc.target/i386/msave-args-mov.c
+++ b/gcc/testsuite/gcc.target/i386/msave-args-mov.c
@@ -1,0 +1,26 @@
+/* { dg-do run { target { { i?86-*-solaris2.* } && lp64 } } } */
+/* { dg-options "-msave-args -mforce-save-regs-using-mov -save-temps" } */
+
+#include <stdio.h>
+
+void t(int, int, int, int, int) __attribute__ ((noinline));
+
+int
+main(int argc, char **argv)
+{
+	t(1, 2, 3, 4, 5);
+	return (0);
+}
+
+void
+t(int a, int b, int c, int d, int e)
+{
+	printf("%d %d %d %d %d", a, b, c, d, e);
+}
+
+/* { dg-final { scan-assembler "movq\t%rdi, -8\\(%rbp\\)" } } */
+/* { dg-final { scan-assembler "movq\t%rsi, -16\\(%rbp\\)" } } */
+/* { dg-final { scan-assembler "movq\t%rdx, -24\\(%rbp\\)" } } */
+/* { dg-final { scan-assembler "movq\t%rcx, -32\\(%rbp\\)" } } */
+/* { dg-final { scan-assembler "movq\t%r8, -40\\(%rbp\\)" } } */
+/* { dg-final { cleanup-saved-temps } } */

--- a/gcc/testsuite/gcc.target/i386/msave-args-push.c
+++ b/gcc/testsuite/gcc.target/i386/msave-args-push.c
@@ -1,0 +1,26 @@
+/* { dg-do run { target { { i?86-*-solaris2.* } && lp64 } } } */
+/* { dg-options "-msave-args -save-temps " } */
+
+#include <stdio.h>
+
+void t(int, int, int, int, int) __attribute__ ((noinline));
+
+int
+main(int argc, char **argv)
+{
+	t(1, 2, 3, 4, 5);
+	return (0);
+}
+
+void
+t(int a, int b, int c, int d, int e)
+{
+	printf("%d %d %d %d %d", a, b, c, d, e);
+}
+
+/* { dg-final { scan-assembler "pushq\t%rdi" } } */
+/* { dg-final { scan-assembler "pushq\t%rsi" } } */
+/* { dg-final { scan-assembler "pushq\t%rdx" } } */
+/* { dg-final { scan-assembler "pushq\t%rcx" } } */
+/* { dg-final { scan-assembler "pushq\t%r8" } } */
+/* { dg-final { cleanup-saved-temps } } */

--- a/gcc/testsuite/gcc.target/i386/pr78691-i386.c
+++ b/gcc/testsuite/gcc.target/i386/pr78691-i386.c
@@ -1,5 +1,6 @@
 /* PR tree-optimization/78691 */
 /* { dg-options "-Os -m16" } */
+/* { dg-skip-if "" { *-*-* } "-msave-args" "" } */
 
 int fn1(char *p1, char *p2) {
   int a;

--- a/gcc/testsuite/gcc.target/i386/pr80569.c
+++ b/gcc/testsuite/gcc.target/i386/pr80569.c
@@ -1,6 +1,7 @@
 /* PR target/80569 */
 /* { dg-do assemble } */
 /* { dg-options "-O2 -m16 -march=haswell" } */
+/* { dg-skip-if "" { *-*-* } "-msave-args" "" } */
 
 void load_kernel(void *setup_addr)
 {

--- a/gcc/testsuite/gcc.target/i386/retarg.c
+++ b/gcc/testsuite/gcc.target/i386/retarg.c
@@ -1,5 +1,6 @@
 /* { dg-do compile { target { ! ia32 } } } */
 /* { dg-options "-O2" } */
+/* { dg-skip-if "" { *-*-* } "-msave-args" "" } */
 
 #include <string.h>
 

--- a/gcc/testsuite/gcc.target/i386/strict-cc.c
+++ b/gcc/testsuite/gcc.target/i386/strict-cc.c
@@ -1,0 +1,24 @@
+/* { dg-do compile { target { ilp32 } } } */
+/* { dg-options "-O2 -funit-at-a-time -fstrict-calling-conventions"  } */
+/* { dg-final { scan-assembler "pushl.*\\\$1" } } */
+/* { dg-final { scan-assembler "pushl.*\\\$2" } } */
+/* { dg-final { scan-assembler "pushl.*\\\$3" } } */
+/* { dg-final { scan-assembler "pushl.*\\\$4" } } */
+/* { dg-final { scan-assembler "pushl.*\\\$5" } } */
+
+#include <stdio.h>
+
+/* Verify that local calling convention is not used if strict conventions.  */
+static int t(int, int, int, int, int) __attribute__ ((noinline));
+
+int
+m()
+{
+    t(1, 2, 3, 4, 5);
+}
+
+static int
+t(int a, int b, int c, int d, int e)
+{
+    printf("%d\n", a, b, c, d, e);
+}

--- a/gcc/tree.c
+++ b/gcc/tree.c
@@ -2204,29 +2204,29 @@ build_real_from_int_cst (tree type, const_tree i)
   return v;
 }
 
-/* Return a newly constructed STRING_CST node whose value is
-   the LEN characters at STR.
+/* Return a newly constructed STRING_CST node whose value is the LEN
+   characters at STR when STR is nonnull, or all zeros otherwise.
    Note that for a C string literal, LEN should include the trailing NUL.
    The TREE_TYPE is not initialized.  */
 
 tree
-build_string (int len, const char *str)
+build_string (unsigned len, const char *str /*= NULL */)
 {
-  tree s;
-  size_t length;
-
   /* Do not waste bytes provided by padding of struct tree_string.  */
-  length = len + offsetof (struct tree_string, str) + 1;
+  unsigned size = len + offsetof (struct tree_string, str) + 1;
 
-  record_node_allocation_statistics (STRING_CST, length);
+  record_node_allocation_statistics (STRING_CST, size);
 
-  s = (tree) ggc_internal_alloc (length);
+  tree s = (tree) ggc_internal_alloc (size);
 
   memset (s, 0, sizeof (struct tree_typed));
   TREE_SET_CODE (s, STRING_CST);
   TREE_CONSTANT (s) = 1;
   TREE_STRING_LENGTH (s) = len;
-  memcpy (s->string.str, str, len);
+  if (str)
+    memcpy (s->string.str, str, len);
+  else
+    memset (s->string.str, 0, len);
   s->string.str[len] = '\0';
 
   return s;
@@ -11614,12 +11614,12 @@ build_alloca_call_expr (tree size, unsigned int align, HOST_WIDE_INT max_size)
 
 /* Create a new constant string literal of type ELTYPE[SIZE] (or LEN
    if SIZE == -1) and return a tree node representing char* pointer to
-   it as an ADDR_EXPR (ARRAY_REF (ELTYPE, ...)).  The STRING_CST value
-   is the LEN bytes at STR (the representation of the string, which may
-   be wide).  */
+   it as an ADDR_EXPR (ARRAY_REF (ELTYPE, ...)).  When STR is nonnull
+   the STRING_CST value is the LEN bytes at STR (the representation
+   of the string, which may be wide).  Otherwise it's all zeros.  */
 
 tree
-build_string_literal (int len, const char *str,
+build_string_literal (unsigned len, const char *str /* = NULL */,
 		      tree eltype /* = char_type_node */,
 		      unsigned HOST_WIDE_INT size /* = -1 */)
 {

--- a/gcc/tree.h
+++ b/gcc/tree.h
@@ -4415,7 +4415,7 @@ extern tree build_one_cst (tree);
 extern tree build_minus_one_cst (tree);
 extern tree build_all_ones_cst (tree);
 extern tree build_zero_cst (tree);
-extern tree build_string (int, const char *);
+extern tree build_string (unsigned, const char * = NULL);
 extern tree build_poly_int_cst (tree, const poly_wide_int_ref &);
 extern tree build_tree_list (tree, tree CXX_MEM_STAT_INFO);
 extern tree build_tree_list_vec (const vec<tree, va_gc> * CXX_MEM_STAT_INFO);
@@ -4446,7 +4446,8 @@ extern tree build_call_expr_internal_loc_array (location_t, enum internal_fn,
 extern tree maybe_build_call_expr_loc (location_t, combined_fn, tree,
 				       int, ...);
 extern tree build_alloca_call_expr (tree, unsigned int, HOST_WIDE_INT);
-extern tree build_string_literal (int, const char *, tree = char_type_node,
+extern tree build_string_literal (unsigned, const char * = NULL,
+				  tree = char_type_node,
 				  unsigned HOST_WIDE_INT = HOST_WIDE_INT_M1U);
 
 /* Construct various nodes representing data types.  */

--- a/include/dwarf2.def
+++ b/include/dwarf2.def
@@ -467,6 +467,8 @@ DW_TAG (DW_AT_GNU_denominator, 0x2304)
 /* Biased integer extension.
    See https://gcc.gnu.org/wiki/DW_AT_GNU_bias .  */
 DW_TAG (DW_AT_GNU_bias, 0x2305)
+/* Sun extension. */
+DW_AT (DW_AT_SUN_amd64_parmdump, 0x2224)
 /* UPC extension.  */
 DW_AT (DW_AT_upc_threads_scaled, 0x3210)
 /* PGI (STMicroelectronics) extensions.  */

--- a/libgcc/config.host
+++ b/libgcc/config.host
@@ -280,7 +280,7 @@ case ${host} in
 *-*-solaris2*)
   # Unless linker support and dl_iterate_phdr are present,
   # unwind-dw2-fde-dip.c automatically falls back to unwind-dw2-fde.c.
-  tmake_file="$tmake_file sol2/t-sol2 t-eh-dw2-dip t-crtstuff-pic t-libgcc-pic t-slibgcc t-slibgcc-elf-ver"
+  tmake_file="$tmake_file sol2/t-sol2 t-eh-dw2-dip t-crtstuff-pic t-libgcc-pic t-slibgcc t-slibgcc-elf-ver t-crtstuff-pic"
   if test $with_gnu_ld = yes; then
     tmake_file="$tmake_file t-slibgcc-gld"
   else
@@ -300,6 +300,7 @@ case ${host} in
       i?86-*-solaris2* | x86_64-*-solaris2*)
         # Solaris 10+/x86 provides crt1.o, crti.o, crtn.o, and gcrt1.o as
         # part of the base system.
+        extra_parts="$extra_parts crtbeginS.o crtendS.o"
         ;;
       sparc*-*-solaris2*)
         # Solaris 10+/SPARC lacks crt1.o and gcrt1.o.

--- a/libgo/go/cmd/go/internal/work/gccgo.go
+++ b/libgo/go/cmd/go/internal/work/gccgo.go
@@ -46,7 +46,7 @@ func (gccgoToolchain) linker() string {
 func (gccgoToolchain) ar() string {
 	ar := cfg.Getenv("AR")
 	if ar == "" {
-		ar = "ar"
+		ar = "/usr/bin/gar"
 	}
 	return ar
 }

--- a/libgo/go/go/internal/gccgoimporter/importer_test.go
+++ b/libgo/go/go/internal/gccgoimporter/importer_test.go
@@ -190,7 +190,7 @@ func TestObjImporter(t *testing.T) {
 
 		runImporterTest(t, imp, initmap, &test)
 
-		cmd = exec.Command("ar", "cr", afile, ofile)
+		cmd = exec.Command("/usr/bin/gar", "cr", afile, ofile)
 		out, err = cmd.CombinedOutput()
 		if err != nil {
 			t.Logf("%s", out)

--- a/libgo/runtime/proc.c
+++ b/libgo/runtime/proc.c
@@ -12,6 +12,10 @@
 #include "config.h"
 
 #ifdef HAVE_DL_ITERATE_PHDR
+#ifdef __sun
+#undef _FILE_OFFSET_BITS
+#define _FILE_OFFSET_BITS 32
+#endif
 #include <link.h>
 #endif
 

--- a/libobjc/Makefile.in
+++ b/libobjc/Makefile.in
@@ -308,14 +308,16 @@ $(srcdir)/configure: @MAINT@ configure.ac $(srcdir)/aclocal.m4
 $(srcdir)/aclocal.m4: @MAINT@ $(aclocal_deps)
 	cd $(srcdir) && $(ACLOCAL) $(ACLOCAL_AMFLAGS)
 
-install: install-libs install-headers
+install-strip: INSTALL_STRIP_FLAG = -s
+install install-strip: install-libs install-headers
 
 install-libs: installdirs
 	$(SHELL) $(multi_basedir)/mkinstalldirs $(DESTDIR)$(toolexeclibdir)
-	$(LIBTOOL_INSTALL) $(INSTALL) libobjc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);
+	$(LIBTOOL_INSTALL) $(INSTALL) $(INSTALL_STRIP_FLAG) \
+	  libobjc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);
 	if [ "$(OBJC_BOEHM_GC)" ]; then \
-	  $(LIBTOOL_INSTALL) $(INSTALL) libobjc_gc$(libsuffix).la \
-				$(DESTDIR)$(toolexeclibdir);\
+	  $(LIBTOOL_INSTALL) $(INSTALL) $(INSTALL_STRIP_FLAG) \
+	    libobjc_gc$(libsuffix).la $(DESTDIR)$(toolexeclibdir);\
 	fi
 	$(MULTIDO) $(FLAGS_TO_PASS) multi-do DO="$@"
 	@-$(LIBTOOL) --mode=finish $(DESTDIR)$(toolexeclibdir)
@@ -328,7 +330,7 @@ install-headers:
 	  $(INSTALL_DATA) $${realfile} $(DESTDIR)$(libsubdir)/$(includedirname)/objc; \
 	done
 
-check uninstall install-strip dist installcheck installdirs:
+check uninstall dist installcheck installdirs:
 
 mostlyclean:
 	-$(LIBTOOL_CLEAN) rm -f libobjc$(libsuffix).la libobjc_gc$(libsuffix).la *.lo

--- a/libsanitizer/sanitizer_common/sanitizer_platform_limits_solaris.h
+++ b/libsanitizer/sanitizer_common/sanitizer_platform_limits_solaris.h
@@ -19,6 +19,9 @@
 #include "sanitizer_internal_defs.h"
 #include "sanitizer_platform.h"
 
+struct stat;
+struct dirent;
+
 namespace __sanitizer {
 extern unsigned struct_utsname_sz;
 extern unsigned struct_stat_sz;
@@ -336,6 +339,14 @@ struct __sanitizer_glob_t {
   uptr gl_offs;
   char **gl_pathp;
   int gl_pathn;
+  int gl_matchc;
+  int gl_flags;
+  struct stat **gl_statv;
+  void (*gl_closedir)(void *);
+  struct dirent *(*gl_readdir)(void *);
+  void *(*gl_opendir)(const char *);
+  int (*gl_lstat)(const char *, struct stat *);
+  int (*gl_stat)(const char *, struct stat *);
 };
 
 extern int glob_nomatch;

--- a/libsanitizer/sanitizer_common/sanitizer_posix_libcdep.cpp
+++ b/libsanitizer/sanitizer_common/sanitizer_posix_libcdep.cpp
@@ -64,24 +64,24 @@ void ReleaseMemoryPagesToOS(uptr beg, uptr end) {
     // In the default Solaris compilation environment, madvise() is declared
     // to take a caddr_t arg; casting it to void * results in an invalid
     // conversion error, so use char * instead.
-    madvise((char *)beg_aligned, end_aligned - beg_aligned,
+    posix_madvise((char *)beg_aligned, end_aligned - beg_aligned,
             SANITIZER_MADVISE_DONTNEED);
 }
 
 void SetShadowRegionHugePageMode(uptr addr, uptr size) {
 #ifdef MADV_NOHUGEPAGE  // May not be defined on old systems.
   if (common_flags()->no_huge_pages_for_shadow)
-    madvise((char *)addr, size, MADV_NOHUGEPAGE);
+    posix_madvise((char *)addr, size, MADV_NOHUGEPAGE);
   else
-    madvise((char *)addr, size, MADV_HUGEPAGE);
+    posix_madvise((char *)addr, size, MADV_HUGEPAGE);
 #endif  // MADV_NOHUGEPAGE
 }
 
 bool DontDumpShadowMemory(uptr addr, uptr length) {
 #if defined(MADV_DONTDUMP)
-  return madvise((char *)addr, length, MADV_DONTDUMP) == 0;
+  return posix_madvise((char *)addr, length, MADV_DONTDUMP) == 0;
 #elif defined(MADV_NOCORE)
-  return madvise((char *)addr, length, MADV_NOCORE) == 0;
+  return posix_madvise((char *)addr, length, MADV_NOCORE) == 0;
 #else
   return true;
 #endif  // MADV_DONTDUMP

--- a/libstdc++-v3/acinclude.m4
+++ b/libstdc++-v3/acinclude.m4
@@ -1446,7 +1446,6 @@ AC_DEFUN([GLIBCXX_ENABLE_LIBSTDCXX_TIME], [
         ac_has_nanosleep=yes
         ;;
       solaris*)
-        GLIBCXX_LIBS="$GLIBCXX_LIBS -lrt"
         ac_has_clock_monotonic=yes
         ac_has_clock_realtime=yes
         ac_has_nanosleep=yes

--- a/libstdc++-v3/configure
+++ b/libstdc++-v3/configure
@@ -21154,7 +21154,6 @@ fi
         ac_has_nanosleep=yes
         ;;
       solaris*)
-        GLIBCXX_LIBS="$GLIBCXX_LIBS -lrt"
         ac_has_clock_monotonic=yes
         ac_has_clock_realtime=yes
         ac_has_nanosleep=yes


### PR DESCRIPTION
Here are the test summaries for running this branch on the latest OmniOS bloody (rolling) release:

```
                === gcc Summary for unix//-m32 ===
# of expected passes            144158
# of unexpected failures        104
# of unexpected successes       2
# of expected failures          705
# of unresolved testcases       1
# of unsupported tests          3058
                === gcc Summary for unix//-m64 ===
# of expected passes            144791
# of unexpected failures        87
# of expected failures          696
# of unresolved testcases       1
# of unsupported tests          2436
                === gcc Summary for unix//-m64/-msave-args ===
# of expected passes            144728
# of unexpected failures        143
# of expected failures          696
# of unresolved testcases       1
# of unsupported tests          2440
                === gcc Summary ===
# of expected passes            433677
# of unexpected failures        334
# of unexpected successes       2
# of expected failures          2097
# of unresolved testcases       3
# of unsupported tests          7934
```

and here is the detailed output:

```
                === gcc tests ===

Running target unix//-m32
FAIL: c-c++-common/asan/null-deref-1.c   -O0  output pattern test
FAIL: c-c++-common/asan/null-deref-1.c   -O1  output pattern test
FAIL: c-c++-common/asan/null-deref-1.c   -O2  output pattern test
FAIL: c-c++-common/asan/null-deref-1.c   -O3 -g  output pattern test
FAIL: c-c++-common/asan/null-deref-1.c   -Os  output pattern test
FAIL: c-c++-common/asan/null-deref-1.c   -O2 -flto -flto-partition=none  output pattern test
FAIL: c-c++-common/asan/null-deref-1.c   -O2 -flto  output pattern test
FAIL: gcc.dg/ifcvt-4.c scan-rtl-dump ce1 "2 true changes made"
FAIL: gcc.dg/initpri1.c execution test
FAIL: gcc.dg/initpri3.c execution test
FAIL: gcc.dg/loop-invariant.c scan-rtl-dump loop2_invariant "Decided to move invariant"
FAIL: gcc.dg/stack-check-5.c scan-rtl-dump-times pro_and_epilogue "Stack clash no frame pointer needed" 2
FAIL: gcc.dg/stack-check-5.c scan-rtl-dump-times pro_and_epilogue "Stack clash frame pointer needed" 2
FAIL: gcc.dg/stack-check-5.c scan-rtl-dump-times pro_and_epilogue "Stack clash no residual allocation in prologue" 1
FAIL: gcc.dg/stack-check-5.c scan-rtl-dump-times pro_and_epilogue "Stack clash residual allocation in prologue" 3
FAIL: gcc.dg/stack-check-6.c scan-rtl-dump-times pro_and_epilogue "Stack clash no frame pointer needed" 2
FAIL: gcc.dg/stack-check-6.c scan-rtl-dump-times pro_and_epilogue "Stack clash frame pointer needed" 2
FAIL: gcc.dg/stack-check-6a.c scan-rtl-dump-times pro_and_epilogue "Stack clash no frame pointer needed" 2
FAIL: gcc.dg/stack-check-6a.c scan-rtl-dump-times pro_and_epilogue "Stack clash frame pointer needed" 2
FAIL: gcc.dg/ipa/ipa-icf-38.c scan-ltrans-tree-dump-not optimized "Function bar"
FAIL: gcc.dg/lto/20081120-1 c_lto_20081120-1_0.o-c_lto_20081120-1_1.o link, -flto -r -nostdlib
FAIL: gcc.dg/lto/20081120-2 c_lto_20081120-2_0.o-c_lto_20081120-2_1.o link, -flto -flto-partition=1to1 -r -nostdlib
FAIL: gcc.dg/lto/20081126 c_lto_20081126_0.o-c_lto_20081126_0.o link, -flto -r -nostdlib
FAIL: gcc.dg/lto/20081204-1 c_lto_20081204-1_0.o-c_lto_20081204-1_1.o link, -flto -flto-partition=1to1 -fPIC -r -nostdlib
FAIL: gcc.dg/lto/20081204-2 c_lto_20081204-2_0.o-c_lto_20081204-2_0.o link, -w -flto -fPIC -r -nostdlib
FAIL: gcc.dg/lto/20081212-1 c_lto_20081212-1_0.o-c_lto_20081212-1_0.o link, -r -nostdlib
FAIL: gcc.dg/lto/20081224 c_lto_20081224_0.o-c_lto_20081224_1.o link, -flto -flto-partition=1to1 -r -nostdlib -fPIC
FAIL: gcc.dg/lto/20090116 c_lto_20090116_0.o-c_lto_20090116_0.o link, -O1 -flto -flto-partition=1to1 -fPIC
FAIL: gcc.dg/lto/20090126-1 c_lto_20090126-1_0.o-c_lto_20090126-1_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20090126-2 c_lto_20090126-2_0.o-c_lto_20090126-2_0.o link, -fPIC -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20090219 c_lto_20090219_0.o-c_lto_20090219_0.o link, -O3 -flto -flto-partition=1to1 -fPIC -r -nostdlib
FAIL: gcc.dg/lto/20091013-1 c_lto_20091013-1_0.o-c_lto_20091013-1_2.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091013-1 c_lto_20091013-1_0.o-c_lto_20091013-1_2.o link, -fPIC -r -nostdlib -O2 -flto
FAIL: gcc.dg/lto/20091014-1 c_lto_20091014-1_0.o-c_lto_20091014-1_0.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091015-1 c_lto_20091015-1_0.o-c_lto_20091015-1_2.o link, -fPIC -r -nostdlib -O2 -flto
FAIL: gcc.dg/lto/20091015-1 c_lto_20091015-1_0.o-c_lto_20091015-1_2.o link, -fPIC -r -nostdlib -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20091016-1 c_lto_20091016-1_0.o-c_lto_20091016-1_1.o link, -fPIC -r -nostdlib -O2 -flto
FAIL: gcc.dg/lto/20091020-1 c_lto_20091020-1_0.o-c_lto_20091020-1_1.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091020-2 c_lto_20091020-2_0.o-c_lto_20091020-2_1.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O0 -flto
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O2 -flto
FAIL: gcc.dg/lto/20100426 c_lto_20100426_0.o-c_lto_20100426_0.o link, -r -nostdlib -flto -g
FAIL: gcc.dg/lto/20100430-1 c_lto_20100430-1_0.o-c_lto_20100430-1_0.o link, -O2 -fprofile-arcs -flto -r -nostdlib
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O0 -flto
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O2 -flto
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O0 -flto
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O2 -flto
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O0 -flto
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O2 -flto
FAIL: gcc.dg/lto/20111213-1 c_lto_20111213-1_0.o-c_lto_20111213-1_0.o link,  -flto -g
FAIL: gcc.dg/lto/pr45736 c_lto_pr45736_0.o-c_lto_pr45736_0.o link, -flto -r -O
FAIL: gcc.dg/lto/pr54702 c_lto_pr54702_0.o-c_lto_pr54702_1.o link,  -O2 -flto -w
FAIL: gcc.dg/lto/pr59323-2 c_lto_pr59323-2_0.o-c_lto_pr59323-2_0.o link,  -O2 -g -flto
FAIL: gcc.dg/lto/pr59323 c_lto_pr59323_0.o-c_lto_pr59323_0.o link,  -O2 -g -flto
FAIL: gcc.dg/lto/pr60820 c_lto_pr60820_0.o-c_lto_pr60820_1.o link, -flto -r -nostdlib -O2
FAIL: gcc.dg/lto/pr81406 c_lto_pr81406_0.o-c_lto_pr81406_0.o link,  -O2 -g -flto
FAIL: gcc.dg/lto/pr83388 c_lto_pr83388_0.o-c_lto_pr83388_0.o link,  -O2 -flto -fsanitize=null
FAIL: gcc.dg/lto/pr83388 c_lto_pr83388_0.o-c_lto_pr83388_0.o link,  -O0 -flto -fsanitize=null
FAIL: gcc.dg/lto/pr85870 c_lto_pr85870_0.o-c_lto_pr85870_1.o link,  -flto -O2
FAIL: compiler driver --help=common option(s): "^ +-.*[^:.]\$" absent from output: "  -fstrict-calling-conventions Use strict ABI calling conventions even for static functions"
FAIL: gcc.target/i386/fuse-caller-save-rec.c scan-assembler-not push
FAIL: gcc.target/i386/fuse-caller-save.c scan-assembler-not push
FAIL: gcc.target/i386/memcpy-pr95886.c scan-rtl-dump-times expand "const_int 578437695752307201" 2
FAIL: gcc.target/i386/memcpy-pr95886.c scan-rtl-dump-times expand "const_int 578437695752307200" 1
FAIL: gcc.target/i386/memcpy-pr95886.c scan-rtl-dump-times expand "const_int 578437695752306689" 1
FAIL: gcc.target/i386/memcpy-pr95886.c scan-rtl-dump-times expand "const_int 578437695752110593" 1
FAIL: gcc.target/i386/memcpy-pr95886.c scan-rtl-dump-times expand "const_int 578437695685198337" 1
FAIL: gcc.target/i386/memcpy-pr95886.c scan-rtl-dump-times expand "const_int 578437695685198337" 1
FAIL: gcc.target/i386/memcpy-pr95886.c scan-rtl-dump-times expand "const_int 578431098682540545" 1
FAIL: gcc.target/i386/memcpy-pr95886.c scan-rtl-dump-times expand "const_int 576467370915332609" 1
FAIL: gcc.target/i386/memcpy-pr95886.c scan-rtl-dump-times expand "const_int 1976943448883713" 1
FAIL: gcc.target/i386/pad-5a.c scan-assembler-times nop 2
FAIL: gcc.target/i386/pad-6a.c scan-assembler-times nop 4
FAIL: gcc.target/i386/pad-8.c scan-assembler-times nop 6
FAIL: gcc.target/i386/pr46470.c scan-assembler-not sp
FAIL: gcc.target/i386/pr47735.c scan-assembler-not %[re]bp
FAIL: gcc.target/i386/pr57293.c scan-assembler-not %ebp
FAIL: gcc.target/i386/pr58066.c scan-rtl-dump final "Function foo.*set[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*plus[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*const_int -8.*UNSPEC_TLS.*Function goo"
FAIL: gcc.target/i386/pr58066.c scan-rtl-dump final "Function goo.*set[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*plus[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*const_int -8.*UNSPEC_TLS"
FAIL: gcc.target/i386/pr67265.c (test for excess errors)
XPASS: gcc.target/i386/pr70465-2.c scan-assembler-not fxch\\t%st.1
FAIL: gcc.target/i386/pr78035.c scan-assembler-times cmp 2
FAIL: gcc.target/i386/pr79593.c scan-assembler-not fld[ \\t]+%st
XPASS: gcc.target/i386/pr84101.c scan-tree-dump-not slp2 "basic block vectorized"
FAIL: gcc.target/i386/pr89676.c scan-assembler-times movl 2
FAIL: gcc.target/i386/pr9771-1.c (test for excess errors)
UNRESOLVED: gcc.target/i386/pr9771-1.c compilation failed to produce executable
FAIL: gcc.target/i386/sibcall-4.c scan-assembler-not jmp[ \\t]*.%eax
FAIL: gcc.target/i386/stack-check-12.c scan-assembler pushl\\t%esi
FAIL: gcc.target/i386/stack-check-12.c scan-assembler popl\\t%esi
FAIL: gcc.target/i386/stack-check-17.c scan-assembler-times push[ql] 4
FAIL: c-c++-common/asan/null-deref-1.c   -O0  output pattern test
FAIL: c-c++-common/asan/null-deref-1.c   -O1  output pattern test
FAIL: c-c++-common/asan/null-deref-1.c   -O2  output pattern test
FAIL: c-c++-common/asan/null-deref-1.c   -O2 -flto  output pattern test
FAIL: c-c++-common/asan/null-deref-1.c   -O2 -flto -flto-partition=none  output pattern test
FAIL: c-c++-common/asan/null-deref-1.c   -O3 -g  output pattern test
FAIL: c-c++-common/asan/null-deref-1.c   -Os  output pattern test
FAIL: compiler driver --help=common option(s): "^ +-.*[^:.]\$" absent from output: "  -fstrict-calling-conventions Use strict ABI calling conventions even for static functions"
FAIL: gcc.dg/ifcvt-4.c scan-rtl-dump ce1 "2 true changes made"
FAIL: gcc.dg/initpri1.c execution test
FAIL: gcc.dg/initpri3.c execution test
FAIL: gcc.dg/ipa/ipa-icf-38.c scan-ltrans-tree-dump-not optimized "Function bar"
FAIL: gcc.dg/loop-invariant.c scan-rtl-dump loop2_invariant "Decided to move invariant"
FAIL: gcc.dg/lto/20081120-1 c_lto_20081120-1_0.o-c_lto_20081120-1_1.o link, -flto -r -nostdlib
FAIL: gcc.dg/lto/20081120-2 c_lto_20081120-2_0.o-c_lto_20081120-2_1.o link, -flto -flto-partition=1to1 -r -nostdlib
FAIL: gcc.dg/lto/20081126 c_lto_20081126_0.o-c_lto_20081126_0.o link, -flto -r -nostdlib
FAIL: gcc.dg/lto/20081204-1 c_lto_20081204-1_0.o-c_lto_20081204-1_1.o link, -flto -flto-partition=1to1 -fPIC -r -nostdlib
FAIL: gcc.dg/lto/20081204-2 c_lto_20081204-2_0.o-c_lto_20081204-2_0.o link, -w -flto -fPIC -r -nostdlib
FAIL: gcc.dg/lto/20081212-1 c_lto_20081212-1_0.o-c_lto_20081212-1_0.o link, -r -nostdlib
FAIL: gcc.dg/lto/20081224 c_lto_20081224_0.o-c_lto_20081224_1.o link, -flto -flto-partition=1to1 -r -nostdlib -fPIC
FAIL: gcc.dg/lto/20090116 c_lto_20090116_0.o-c_lto_20090116_0.o link, -O1 -flto -flto-partition=1to1 -fPIC
FAIL: gcc.dg/lto/20090126-1 c_lto_20090126-1_0.o-c_lto_20090126-1_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20090126-2 c_lto_20090126-2_0.o-c_lto_20090126-2_0.o link, -fPIC -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20090219 c_lto_20090219_0.o-c_lto_20090219_0.o link, -O3 -flto -flto-partition=1to1 -fPIC -r -nostdlib
FAIL: gcc.dg/lto/20091013-1 c_lto_20091013-1_0.o-c_lto_20091013-1_2.o link, -fPIC -r -nostdlib -O2 -flto
FAIL: gcc.dg/lto/20091013-1 c_lto_20091013-1_0.o-c_lto_20091013-1_2.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091014-1 c_lto_20091014-1_0.o-c_lto_20091014-1_0.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091015-1 c_lto_20091015-1_0.o-c_lto_20091015-1_2.o link, -fPIC -r -nostdlib -O2 -flto
FAIL: gcc.dg/lto/20091015-1 c_lto_20091015-1_0.o-c_lto_20091015-1_2.o link, -fPIC -r -nostdlib -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20091016-1 c_lto_20091016-1_0.o-c_lto_20091016-1_1.o link, -fPIC -r -nostdlib -O2 -flto
FAIL: gcc.dg/lto/20091020-1 c_lto_20091020-1_0.o-c_lto_20091020-1_1.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091020-2 c_lto_20091020-2_0.o-c_lto_20091020-2_1.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O0 -flto
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O2 -flto
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100426 c_lto_20100426_0.o-c_lto_20100426_0.o link, -r -nostdlib -flto -g
FAIL: gcc.dg/lto/20100430-1 c_lto_20100430-1_0.o-c_lto_20100430-1_0.o link, -O2 -fprofile-arcs -flto -r -nostdlib
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O0 -flto
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O2 -flto
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O0 -flto
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O2 -flto
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O0 -flto
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O2 -flto
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20111213-1 c_lto_20111213-1_0.o-c_lto_20111213-1_0.o link,  -flto -g
FAIL: gcc.dg/lto/pr45736 c_lto_pr45736_0.o-c_lto_pr45736_0.o link, -flto -r -O
FAIL: gcc.dg/lto/pr54702 c_lto_pr54702_0.o-c_lto_pr54702_1.o link,  -O2 -flto -w
FAIL: gcc.dg/lto/pr59323 c_lto_pr59323_0.o-c_lto_pr59323_0.o link,  -O2 -g -flto
FAIL: gcc.dg/lto/pr59323-2 c_lto_pr59323-2_0.o-c_lto_pr59323-2_0.o link,  -O2 -g -flto
FAIL: gcc.dg/lto/pr60820 c_lto_pr60820_0.o-c_lto_pr60820_1.o link, -flto -r -nostdlib -O2
FAIL: gcc.dg/lto/pr81406 c_lto_pr81406_0.o-c_lto_pr81406_0.o link,  -O2 -g -flto
FAIL: gcc.dg/lto/pr83388 c_lto_pr83388_0.o-c_lto_pr83388_0.o link,  -O0 -flto -fsanitize=null
FAIL: gcc.dg/lto/pr83388 c_lto_pr83388_0.o-c_lto_pr83388_0.o link,  -O2 -flto -fsanitize=null
FAIL: gcc.dg/lto/pr85870 c_lto_pr85870_0.o-c_lto_pr85870_1.o link,  -flto -O2
FAIL: gcc.dg/stack-check-5.c scan-rtl-dump-times pro_and_epilogue "Stack clash frame pointer needed" 2
FAIL: gcc.dg/stack-check-5.c scan-rtl-dump-times pro_and_epilogue "Stack clash no frame pointer needed" 2
FAIL: gcc.dg/stack-check-5.c scan-rtl-dump-times pro_and_epilogue "Stack clash no residual allocation in prologue" 1
FAIL: gcc.dg/stack-check-5.c scan-rtl-dump-times pro_and_epilogue "Stack clash residual allocation in prologue" 3
FAIL: gcc.dg/stack-check-6.c scan-rtl-dump-times pro_and_epilogue "Stack clash frame pointer needed" 2
FAIL: gcc.dg/stack-check-6.c scan-rtl-dump-times pro_and_epilogue "Stack clash no frame pointer needed" 2
FAIL: gcc.dg/stack-check-6a.c scan-rtl-dump-times pro_and_epilogue "Stack clash frame pointer needed" 2
FAIL: gcc.dg/stack-check-6a.c scan-rtl-dump-times pro_and_epilogue "Stack clash no frame pointer needed" 2
FAIL: gcc.target/i386/fuse-caller-save-rec.c scan-assembler-not push
FAIL: gcc.target/i386/fuse-caller-save.c scan-assembler-not push
FAIL: gcc.target/i386/memcpy-pr95886.c scan-rtl-dump-times expand "const_int 1976943448883713" 1
FAIL: gcc.target/i386/memcpy-pr95886.c scan-rtl-dump-times expand "const_int 576467370915332609" 1
FAIL: gcc.target/i386/memcpy-pr95886.c scan-rtl-dump-times expand "const_int 578431098682540545" 1
FAIL: gcc.target/i386/memcpy-pr95886.c scan-rtl-dump-times expand "const_int 578437695685198337" 1
FAIL: gcc.target/i386/memcpy-pr95886.c scan-rtl-dump-times expand "const_int 578437695685198337" 1
FAIL: gcc.target/i386/memcpy-pr95886.c scan-rtl-dump-times expand "const_int 578437695752110593" 1
FAIL: gcc.target/i386/memcpy-pr95886.c scan-rtl-dump-times expand "const_int 578437695752306689" 1
FAIL: gcc.target/i386/memcpy-pr95886.c scan-rtl-dump-times expand "const_int 578437695752307200" 1
FAIL: gcc.target/i386/memcpy-pr95886.c scan-rtl-dump-times expand "const_int 578437695752307201" 2
FAIL: gcc.target/i386/pad-5a.c scan-assembler-times nop 2
FAIL: gcc.target/i386/pad-6a.c scan-assembler-times nop 4
FAIL: gcc.target/i386/pad-8.c scan-assembler-times nop 6
FAIL: gcc.target/i386/pr46470.c scan-assembler-not sp
FAIL: gcc.target/i386/pr47735.c scan-assembler-not %[re]bp
FAIL: gcc.target/i386/pr57293.c scan-assembler-not %ebp
FAIL: gcc.target/i386/pr58066.c scan-rtl-dump final "Function foo.*set[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*plus[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*const_int -8.*UNSPEC_TLS.*Function goo"
FAIL: gcc.target/i386/pr58066.c scan-rtl-dump final "Function goo.*set[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*plus[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*const_int -8.*UNSPEC_TLS"
FAIL: gcc.target/i386/pr67265.c (test for excess errors)
XPASS: gcc.target/i386/pr70465-2.c scan-assembler-not fxch\\t%st.1
FAIL: gcc.target/i386/pr78035.c scan-assembler-times cmp 2
FAIL: gcc.target/i386/pr79593.c scan-assembler-not fld[ \\t]+%st
XPASS: gcc.target/i386/pr84101.c scan-tree-dump-not slp2 "basic block vectorized"
FAIL: gcc.target/i386/pr89676.c scan-assembler-times movl 2
FAIL: gcc.target/i386/pr9771-1.c (test for excess errors)
UNRESOLVED: gcc.target/i386/pr9771-1.c compilation failed to produce executable
FAIL: gcc.target/i386/sibcall-4.c scan-assembler-not jmp[ \\t]*.%eax
FAIL: gcc.target/i386/stack-check-12.c scan-assembler popl\\t%esi
FAIL: gcc.target/i386/stack-check-12.c scan-assembler pushl\\t%esi
FAIL: gcc.target/i386/stack-check-17.c scan-assembler-times push[ql] 4

                === gcc Summary for unix//-m32 ===

# of expected passes            144158
# of unexpected failures        104
# of unexpected successes       2
# of expected failures          705
# of unresolved testcases       1
# of unsupported tests          3058

Running target unix//-m64
FAIL: gcc.dg/initpri1.c execution test
FAIL: gcc.dg/initpri3.c execution test
FAIL: gcc.dg/stack-check-5.c scan-rtl-dump-times pro_and_epilogue "Stack clash no frame pointer needed" 2
FAIL: gcc.dg/stack-check-5.c scan-rtl-dump-times pro_and_epilogue "Stack clash frame pointer needed" 2
FAIL: gcc.dg/stack-check-6.c scan-rtl-dump-times pro_and_epilogue "Stack clash no frame pointer needed" 2
FAIL: gcc.dg/stack-check-6.c scan-rtl-dump-times pro_and_epilogue "Stack clash frame pointer needed" 2
FAIL: gcc.dg/stack-check-6a.c scan-rtl-dump-times pro_and_epilogue "Stack clash no frame pointer needed" 2
FAIL: gcc.dg/stack-check-6a.c scan-rtl-dump-times pro_and_epilogue "Stack clash frame pointer needed" 2
FAIL: gcc.dg/ipa/ipa-icf-38.c scan-ltrans-tree-dump-not optimized "Function bar"
FAIL: gcc.dg/lto/20081120-1 c_lto_20081120-1_0.o-c_lto_20081120-1_1.o link, -flto -r -nostdlib
FAIL: gcc.dg/lto/20081120-2 c_lto_20081120-2_0.o-c_lto_20081120-2_1.o link, -flto -flto-partition=1to1 -r -nostdlib
FAIL: gcc.dg/lto/20081126 c_lto_20081126_0.o-c_lto_20081126_0.o link, -flto -r -nostdlib
FAIL: gcc.dg/lto/20081204-1 c_lto_20081204-1_0.o-c_lto_20081204-1_1.o link, -flto -flto-partition=1to1 -fPIC -r -nostdlib
FAIL: gcc.dg/lto/20081204-2 c_lto_20081204-2_0.o-c_lto_20081204-2_0.o link, -w -flto -fPIC -r -nostdlib
FAIL: gcc.dg/lto/20081212-1 c_lto_20081212-1_0.o-c_lto_20081212-1_0.o link, -r -nostdlib
FAIL: gcc.dg/lto/20081224 c_lto_20081224_0.o-c_lto_20081224_1.o link, -flto -flto-partition=1to1 -r -nostdlib -fPIC
FAIL: gcc.dg/lto/20090116 c_lto_20090116_0.o-c_lto_20090116_0.o link, -O1 -flto -flto-partition=1to1 -fPIC
FAIL: gcc.dg/lto/20090126-1 c_lto_20090126-1_0.o-c_lto_20090126-1_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20090126-2 c_lto_20090126-2_0.o-c_lto_20090126-2_0.o link, -fPIC -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20090219 c_lto_20090219_0.o-c_lto_20090219_0.o link, -O3 -flto -flto-partition=1to1 -fPIC -r -nostdlib
FAIL: gcc.dg/lto/20091013-1 c_lto_20091013-1_0.o-c_lto_20091013-1_2.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091013-1 c_lto_20091013-1_0.o-c_lto_20091013-1_2.o link, -fPIC -r -nostdlib -O2 -flto
FAIL: gcc.dg/lto/20091014-1 c_lto_20091014-1_0.o-c_lto_20091014-1_0.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091015-1 c_lto_20091015-1_0.o-c_lto_20091015-1_2.o link, -fPIC -r -nostdlib -O2 -flto
FAIL: gcc.dg/lto/20091015-1 c_lto_20091015-1_0.o-c_lto_20091015-1_2.o link, -fPIC -r -nostdlib -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20091016-1 c_lto_20091016-1_0.o-c_lto_20091016-1_1.o link, -fPIC -r -nostdlib -O2 -flto
FAIL: gcc.dg/lto/20091020-1 c_lto_20091020-1_0.o-c_lto_20091020-1_1.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091020-2 c_lto_20091020-2_0.o-c_lto_20091020-2_1.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O0 -flto
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O2 -flto
FAIL: gcc.dg/lto/20100426 c_lto_20100426_0.o-c_lto_20100426_0.o link, -r -nostdlib -flto -g
FAIL: gcc.dg/lto/20100430-1 c_lto_20100430-1_0.o-c_lto_20100430-1_0.o link, -O2 -fprofile-arcs -flto -r -nostdlib
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O0 -flto
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O2 -flto
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O0 -flto
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O2 -flto
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O0 -flto
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O2 -flto
FAIL: gcc.dg/lto/20111213-1 c_lto_20111213-1_0.o-c_lto_20111213-1_0.o link,  -flto -g
FAIL: gcc.dg/lto/pr45736 c_lto_pr45736_0.o-c_lto_pr45736_0.o link, -flto -r -O
FAIL: gcc.dg/lto/pr54702 c_lto_pr54702_0.o-c_lto_pr54702_1.o link,  -O2 -flto -w
FAIL: gcc.dg/lto/pr59323-2 c_lto_pr59323-2_0.o-c_lto_pr59323-2_0.o link,  -O2 -g -flto
FAIL: gcc.dg/lto/pr59323 c_lto_pr59323_0.o-c_lto_pr59323_0.o link,  -O2 -g -flto
FAIL: gcc.dg/lto/pr60820 c_lto_pr60820_0.o-c_lto_pr60820_1.o link, -flto -r -nostdlib -O2
FAIL: gcc.dg/lto/pr81406 c_lto_pr81406_0.o-c_lto_pr81406_0.o link,  -O2 -g -flto
FAIL: gcc.dg/lto/pr83388 c_lto_pr83388_0.o-c_lto_pr83388_0.o link,  -O2 -flto -fsanitize=null
FAIL: gcc.dg/lto/pr83388 c_lto_pr83388_0.o-c_lto_pr83388_0.o link,  -O0 -flto -fsanitize=null
FAIL: gcc.dg/lto/pr85870 c_lto_pr85870_0.o-c_lto_pr85870_1.o link,  -flto -O2
FAIL: gcc.dg/tree-ssa/pr43491.c (test for excess errors)
FAIL: compiler driver --help=common option(s): "^ +-.*[^:.]\$" absent from output: "  -fstrict-calling-conventions Use strict ABI calling conventions even for static functions"
FAIL: gcc.target/i386/amd64-abi-3.c scan-assembler subq[\\\\t ]*\\\\\$88,[\\\\t ]*%rsp
FAIL: gcc.target/i386/fuse-caller-save-rec.c scan-assembler-not push
FAIL: gcc.target/i386/fuse-caller-save-rec.c scan-assembler-not pop
FAIL: gcc.target/i386/fuse-caller-save.c scan-assembler-not push
FAIL: gcc.target/i386/fuse-caller-save.c scan-assembler-not pop
FAIL: gcc.target/i386/ipa-stack-alignment-2.c scan-assembler sub.*%.sp
FAIL: gcc.target/i386/ipa-stack-alignment.c scan-assembler sub.*%.sp
FAIL: gcc.target/i386/max-stack-align.c (test for excess errors)
FAIL: gcc.target/i386/pr46470.c scan-assembler-not sp
FAIL: gcc.target/i386/pr58066.c scan-rtl-dump final "Function foo.*set[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*plus[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*const_int -8.*UNSPEC_TLS.*Function goo"
FAIL: gcc.target/i386/pr58066.c scan-rtl-dump final "Function goo.*set[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*plus[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*const_int -8.*UNSPEC_TLS"
FAIL: gcc.target/i386/pr64905.c (internal compiler error)
FAIL: gcc.target/i386/pr64905.c (test for excess errors)
UNRESOLVED: gcc.target/i386/pr64905.c scan-assembler-not movl[ \\t]0\\\\(%.*\\\\), %.*
FAIL: gcc.target/i386/pr85667-10.c scan-assembler-times addsd[ \\t]*40\\\\(%rsp\\\\), .* 1
FAIL: gcc.target/i386/pr85667-8.c scan-assembler-times addss[ \\t]*40\\\\(%rsp\\\\), .* 1
FAIL: gcc.target/i386/stack-check-12.c scan-assembler pushq\\t%rax
FAIL: gcc.target/i386/stack-check-12.c scan-assembler popq\\t%rax
FAIL: gcc.target/i386/stack-check-17.c scan-assembler-times push[ql] 2
FAIL: compiler driver --help=common option(s): "^ +-.*[^:.]\$" absent from output: "  -fstrict-calling-conventions Use strict ABI calling conventions even for static functions"
FAIL: gcc.dg/initpri1.c execution test
FAIL: gcc.dg/initpri3.c execution test
FAIL: gcc.dg/ipa/ipa-icf-38.c scan-ltrans-tree-dump-not optimized "Function bar"
FAIL: gcc.dg/lto/20081120-1 c_lto_20081120-1_0.o-c_lto_20081120-1_1.o link, -flto -r -nostdlib
FAIL: gcc.dg/lto/20081120-2 c_lto_20081120-2_0.o-c_lto_20081120-2_1.o link, -flto -flto-partition=1to1 -r -nostdlib
FAIL: gcc.dg/lto/20081126 c_lto_20081126_0.o-c_lto_20081126_0.o link, -flto -r -nostdlib
FAIL: gcc.dg/lto/20081204-1 c_lto_20081204-1_0.o-c_lto_20081204-1_1.o link, -flto -flto-partition=1to1 -fPIC -r -nostdlib
FAIL: gcc.dg/lto/20081204-2 c_lto_20081204-2_0.o-c_lto_20081204-2_0.o link, -w -flto -fPIC -r -nostdlib
FAIL: gcc.dg/lto/20081212-1 c_lto_20081212-1_0.o-c_lto_20081212-1_0.o link, -r -nostdlib
FAIL: gcc.dg/lto/20081224 c_lto_20081224_0.o-c_lto_20081224_1.o link, -flto -flto-partition=1to1 -r -nostdlib -fPIC
FAIL: gcc.dg/lto/20090116 c_lto_20090116_0.o-c_lto_20090116_0.o link, -O1 -flto -flto-partition=1to1 -fPIC
FAIL: gcc.dg/lto/20090126-1 c_lto_20090126-1_0.o-c_lto_20090126-1_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20090126-2 c_lto_20090126-2_0.o-c_lto_20090126-2_0.o link, -fPIC -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20090219 c_lto_20090219_0.o-c_lto_20090219_0.o link, -O3 -flto -flto-partition=1to1 -fPIC -r -nostdlib
FAIL: gcc.dg/lto/20091013-1 c_lto_20091013-1_0.o-c_lto_20091013-1_2.o link, -fPIC -r -nostdlib -O2 -flto
FAIL: gcc.dg/lto/20091013-1 c_lto_20091013-1_0.o-c_lto_20091013-1_2.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091014-1 c_lto_20091014-1_0.o-c_lto_20091014-1_0.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091015-1 c_lto_20091015-1_0.o-c_lto_20091015-1_2.o link, -fPIC -r -nostdlib -O2 -flto
FAIL: gcc.dg/lto/20091015-1 c_lto_20091015-1_0.o-c_lto_20091015-1_2.o link, -fPIC -r -nostdlib -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20091016-1 c_lto_20091016-1_0.o-c_lto_20091016-1_1.o link, -fPIC -r -nostdlib -O2 -flto
FAIL: gcc.dg/lto/20091020-1 c_lto_20091020-1_0.o-c_lto_20091020-1_1.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091020-2 c_lto_20091020-2_0.o-c_lto_20091020-2_1.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O0 -flto
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O2 -flto
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100426 c_lto_20100426_0.o-c_lto_20100426_0.o link, -r -nostdlib -flto -g
FAIL: gcc.dg/lto/20100430-1 c_lto_20100430-1_0.o-c_lto_20100430-1_0.o link, -O2 -fprofile-arcs -flto -r -nostdlib
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O0 -flto
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O2 -flto
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O0 -flto
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O2 -flto
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O0 -flto
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O2 -flto
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20111213-1 c_lto_20111213-1_0.o-c_lto_20111213-1_0.o link,  -flto -g
FAIL: gcc.dg/lto/pr45736 c_lto_pr45736_0.o-c_lto_pr45736_0.o link, -flto -r -O
FAIL: gcc.dg/lto/pr54702 c_lto_pr54702_0.o-c_lto_pr54702_1.o link,  -O2 -flto -w
FAIL: gcc.dg/lto/pr59323 c_lto_pr59323_0.o-c_lto_pr59323_0.o link,  -O2 -g -flto
FAIL: gcc.dg/lto/pr59323-2 c_lto_pr59323-2_0.o-c_lto_pr59323-2_0.o link,  -O2 -g -flto
FAIL: gcc.dg/lto/pr60820 c_lto_pr60820_0.o-c_lto_pr60820_1.o link, -flto -r -nostdlib -O2
FAIL: gcc.dg/lto/pr81406 c_lto_pr81406_0.o-c_lto_pr81406_0.o link,  -O2 -g -flto
FAIL: gcc.dg/lto/pr83388 c_lto_pr83388_0.o-c_lto_pr83388_0.o link,  -O0 -flto -fsanitize=null
FAIL: gcc.dg/lto/pr83388 c_lto_pr83388_0.o-c_lto_pr83388_0.o link,  -O2 -flto -fsanitize=null
FAIL: gcc.dg/lto/pr85870 c_lto_pr85870_0.o-c_lto_pr85870_1.o link,  -flto -O2
FAIL: gcc.dg/stack-check-5.c scan-rtl-dump-times pro_and_epilogue "Stack clash frame pointer needed" 2
FAIL: gcc.dg/stack-check-5.c scan-rtl-dump-times pro_and_epilogue "Stack clash no frame pointer needed" 2
FAIL: gcc.dg/stack-check-6.c scan-rtl-dump-times pro_and_epilogue "Stack clash frame pointer needed" 2
FAIL: gcc.dg/stack-check-6.c scan-rtl-dump-times pro_and_epilogue "Stack clash no frame pointer needed" 2
FAIL: gcc.dg/stack-check-6a.c scan-rtl-dump-times pro_and_epilogue "Stack clash frame pointer needed" 2
FAIL: gcc.dg/stack-check-6a.c scan-rtl-dump-times pro_and_epilogue "Stack clash no frame pointer needed" 2
FAIL: gcc.dg/tree-ssa/pr43491.c (test for excess errors)
FAIL: gcc.target/i386/amd64-abi-3.c scan-assembler subq[\\\\t ]*\\\\\$88,[\\\\t ]*%rsp
FAIL: gcc.target/i386/fuse-caller-save-rec.c scan-assembler-not pop
FAIL: gcc.target/i386/fuse-caller-save-rec.c scan-assembler-not push
FAIL: gcc.target/i386/fuse-caller-save.c scan-assembler-not pop
FAIL: gcc.target/i386/fuse-caller-save.c scan-assembler-not push
FAIL: gcc.target/i386/ipa-stack-alignment-2.c scan-assembler sub.*%.sp
FAIL: gcc.target/i386/ipa-stack-alignment.c scan-assembler sub.*%.sp
FAIL: gcc.target/i386/max-stack-align.c (test for excess errors)
FAIL: gcc.target/i386/pr46470.c scan-assembler-not sp
FAIL: gcc.target/i386/pr58066.c scan-rtl-dump final "Function foo.*set[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*plus[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*const_int -8.*UNSPEC_TLS.*Function goo"
FAIL: gcc.target/i386/pr58066.c scan-rtl-dump final "Function goo.*set[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*plus[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*const_int -8.*UNSPEC_TLS"
FAIL: gcc.target/i386/pr64905.c (internal compiler error)
FAIL: gcc.target/i386/pr64905.c (test for excess errors)
UNRESOLVED: gcc.target/i386/pr64905.c scan-assembler-not movl[ \\t]0\\\\(%.*\\\\), %.*
FAIL: gcc.target/i386/pr85667-10.c scan-assembler-times addsd[ \\t]*40\\\\(%rsp\\\\), .* 1
FAIL: gcc.target/i386/pr85667-8.c scan-assembler-times addss[ \\t]*40\\\\(%rsp\\\\), .* 1
FAIL: gcc.target/i386/stack-check-12.c scan-assembler popq\\t%rax
FAIL: gcc.target/i386/stack-check-12.c scan-assembler pushq\\t%rax
FAIL: gcc.target/i386/stack-check-17.c scan-assembler-times push[ql] 2
FAIL: gcc.target/i386/vartrack-1.c scan-rtl-dump-times vartrack "[0-9][0-9]*: {\\\\[argp:DI-0x10\\\\]=bx:DI;sp:DI=argp:DI-0x10;}" 1
FAIL: gcc.target/i386/vartrack-1.c scan-rtl-dump-times vartrack "[0-9][0-9]*: {bx:DI=\\\\[argp:DI-0x10\\\\];sp:DI=argp:DI-0x8;}" 1
FAIL: gcc.target/x86_64/abi/callabi/leaf-2.c scan-assembler-not %rsp
FAIL: gcc.target/i386/vartrack-1.c scan-rtl-dump-times vartrack "[0-9][0-9]*: {\\\\[argp:DI-0x10\\\\]=bx:DI;sp:DI=argp:DI-0x10;}" 1
FAIL: gcc.target/i386/vartrack-1.c scan-rtl-dump-times vartrack "[0-9][0-9]*: {bx:DI=\\\\[argp:DI-0x10\\\\];sp:DI=argp:DI-0x8;}" 1
FAIL: gcc.target/x86_64/abi/callabi/leaf-2.c scan-assembler-not %rsp

                === gcc Summary for unix//-m64 ===

# of expected passes            144791
# of unexpected failures        87
# of expected failures          696
# of unresolved testcases       1
# of unsupported tests          2436

Running target unix//-m64/-msave-args
FAIL: gcc.dg/initpri1.c execution test
FAIL: gcc.dg/initpri3.c execution test
FAIL: gcc.dg/stack-check-5.c scan-rtl-dump-times pro_and_epilogue "Stack clash no frame pointer needed" 2
FAIL: gcc.dg/stack-check-5.c scan-rtl-dump-times pro_and_epilogue "Stack clash frame pointer needed" 2
FAIL: gcc.dg/stack-check-5.c scan-rtl-dump-times pro_and_epilogue "Stack clash no residual allocation in prologue" 1
FAIL: gcc.dg/stack-check-5.c scan-rtl-dump-times pro_and_epilogue "Stack clash residual allocation in prologue" 3
FAIL: gcc.dg/stack-check-6.c scan-rtl-dump-times pro_and_epilogue "Stack clash no frame pointer needed" 2
FAIL: gcc.dg/stack-check-6.c scan-rtl-dump-times pro_and_epilogue "Stack clash frame pointer needed" 2
FAIL: gcc.dg/stack-check-6a.c scan-rtl-dump-times pro_and_epilogue "Stack clash no frame pointer needed" 2
FAIL: gcc.dg/stack-check-6a.c scan-rtl-dump-times pro_and_epilogue "Stack clash frame pointer needed" 2
FAIL: gcc.dg/ipa/ipa-icf-38.c scan-ltrans-tree-dump-not optimized "Function bar"
FAIL: gcc.dg/lto/20081120-1 c_lto_20081120-1_0.o-c_lto_20081120-1_1.o link, -flto -r -nostdlib
FAIL: gcc.dg/lto/20081120-2 c_lto_20081120-2_0.o-c_lto_20081120-2_1.o link, -flto -flto-partition=1to1 -r -nostdlib
FAIL: gcc.dg/lto/20081126 c_lto_20081126_0.o-c_lto_20081126_0.o link, -flto -r -nostdlib
FAIL: gcc.dg/lto/20081204-1 c_lto_20081204-1_0.o-c_lto_20081204-1_1.o link, -flto -flto-partition=1to1 -fPIC -r -nostdlib
FAIL: gcc.dg/lto/20081204-2 c_lto_20081204-2_0.o-c_lto_20081204-2_0.o link, -w -flto -fPIC -r -nostdlib
FAIL: gcc.dg/lto/20081212-1 c_lto_20081212-1_0.o-c_lto_20081212-1_0.o link, -r -nostdlib
FAIL: gcc.dg/lto/20081224 c_lto_20081224_0.o-c_lto_20081224_1.o link, -flto -flto-partition=1to1 -r -nostdlib -fPIC
FAIL: gcc.dg/lto/20090116 c_lto_20090116_0.o-c_lto_20090116_0.o link, -O1 -flto -flto-partition=1to1 -fPIC
FAIL: gcc.dg/lto/20090126-1 c_lto_20090126-1_0.o-c_lto_20090126-1_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20090126-2 c_lto_20090126-2_0.o-c_lto_20090126-2_0.o link, -fPIC -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20090219 c_lto_20090219_0.o-c_lto_20090219_0.o link, -O3 -flto -flto-partition=1to1 -fPIC -r -nostdlib
FAIL: gcc.dg/lto/20091013-1 c_lto_20091013-1_0.o-c_lto_20091013-1_2.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091013-1 c_lto_20091013-1_0.o-c_lto_20091013-1_2.o link, -fPIC -r -nostdlib -O2 -flto
FAIL: gcc.dg/lto/20091014-1 c_lto_20091014-1_0.o-c_lto_20091014-1_0.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091015-1 c_lto_20091015-1_0.o-c_lto_20091015-1_2.o link, -fPIC -r -nostdlib -O2 -flto
FAIL: gcc.dg/lto/20091015-1 c_lto_20091015-1_0.o-c_lto_20091015-1_2.o link, -fPIC -r -nostdlib -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20091016-1 c_lto_20091016-1_0.o-c_lto_20091016-1_1.o link, -fPIC -r -nostdlib -O2 -flto
FAIL: gcc.dg/lto/20091020-1 c_lto_20091020-1_0.o-c_lto_20091020-1_1.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091020-2 c_lto_20091020-2_0.o-c_lto_20091020-2_1.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O0 -flto
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O2 -flto
FAIL: gcc.dg/lto/20100426 c_lto_20100426_0.o-c_lto_20100426_0.o link, -r -nostdlib -flto -g
FAIL: gcc.dg/lto/20100430-1 c_lto_20100430-1_0.o-c_lto_20100430-1_0.o link, -O2 -fprofile-arcs -flto -r -nostdlib
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O0 -flto
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O2 -flto
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O0 -flto
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O2 -flto
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O0 -flto
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O2 -flto
FAIL: gcc.dg/lto/20111213-1 c_lto_20111213-1_0.o-c_lto_20111213-1_0.o link,  -flto -g
FAIL: gcc.dg/lto/pr45736 c_lto_pr45736_0.o-c_lto_pr45736_0.o link, -flto -r -O
FAIL: gcc.dg/lto/pr54702 c_lto_pr54702_0.o-c_lto_pr54702_1.o link,  -O2 -flto -w
FAIL: gcc.dg/lto/pr59323-2 c_lto_pr59323-2_0.o-c_lto_pr59323-2_0.o link,  -O2 -g -flto
FAIL: gcc.dg/lto/pr59323 c_lto_pr59323_0.o-c_lto_pr59323_0.o link,  -O2 -g -flto
FAIL: gcc.dg/lto/pr60820 c_lto_pr60820_0.o-c_lto_pr60820_1.o link, -flto -r -nostdlib -O2
FAIL: gcc.dg/lto/pr81406 c_lto_pr81406_0.o-c_lto_pr81406_0.o link,  -O2 -g -flto
FAIL: gcc.dg/lto/pr83388 c_lto_pr83388_0.o-c_lto_pr83388_0.o link,  -O2 -flto -fsanitize=null
FAIL: gcc.dg/lto/pr83388 c_lto_pr83388_0.o-c_lto_pr83388_0.o link,  -O0 -flto -fsanitize=null
FAIL: gcc.dg/lto/pr85870 c_lto_pr85870_0.o-c_lto_pr85870_1.o link,  -flto -O2
FAIL: gcc.dg/tree-ssa/pr43491.c (test for excess errors)
FAIL: compiler driver --help=common option(s): "^ +-.*[^:.]\$" absent from output: "  -fstrict-calling-conventions Use strict ABI calling conventions even for static functions"
FAIL: gcc.target/i386/align-limit.c scan-assembler .p2align 6,,1
FAIL: gcc.target/i386/amd64-abi-3.c scan-assembler subq[\\\\t ]*\\\\\$88,[\\\\t ]*%rsp
FAIL: gcc.target/i386/fuse-caller-save-rec.c scan-assembler-not push
FAIL: gcc.target/i386/fuse-caller-save.c scan-assembler-not push
FAIL: gcc.target/i386/ipa-stack-alignment-2.c scan-assembler sub.*%.sp
FAIL: gcc.target/i386/ipa-stack-alignment.c scan-assembler sub.*%.sp
FAIL: gcc.target/i386/max-stack-align.c (test for excess errors)
FAIL: gcc.target/i386/minmax-6.c scan-assembler-not rsp
FAIL: gcc.target/i386/minmax-7.c scan-assembler-not rsp
FAIL: gcc.target/i386/pad-1.c scan-assembler rep
FAIL: gcc.target/i386/pad-2.c scan-assembler-times nop 8
FAIL: gcc.target/i386/pad-5b.c scan-assembler-times nop 4
FAIL: gcc.target/i386/pad-6b.c scan-assembler-times nop 6
FAIL: gcc.target/i386/pad-8.c scan-assembler-times nop 6
FAIL: gcc.target/i386/pad-9.c scan-assembler-times nop 4
FAIL: gcc.target/i386/pr22076.c scan-assembler-times movq 2
FAIL: gcc.target/i386/pr32661-1.c scan-assembler-times mov 2
FAIL: gcc.target/i386/pr34256.c scan-assembler-times mov 3
FAIL: gcc.target/i386/pr36246.c scan-assembler-not movq
FAIL: gcc.target/i386/pr46470.c scan-assembler-not sp
FAIL: gcc.target/i386/pr47735.c scan-assembler-not %[re]bp
FAIL: gcc.target/i386/pr48037-1.c scan-assembler-not %rsp
FAIL: gcc.target/i386/pr58066.c scan-rtl-dump final "Function foo.*set[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*plus[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*const_int -8.*UNSPEC_TLS.*Function goo"
FAIL: gcc.target/i386/pr58066.c scan-rtl-dump final "Function goo.*set[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*plus[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*const_int -8.*UNSPEC_TLS"
FAIL: gcc.target/i386/pr59501-1a.c scan-assembler-not and[^\\n\\r]*sp
FAIL: gcc.target/i386/pr59501-2a.c scan-assembler-not and[^\\n\\r]*sp
FAIL: gcc.target/i386/pr59501-3a.c scan-assembler-not and[^\\n\\r]*sp
FAIL: gcc.target/i386/pr59501-4a.c scan-assembler-not and[^\\n\\r]*sp
FAIL: gcc.target/i386/pr64905.c (internal compiler error)
FAIL: gcc.target/i386/pr64905.c (test for excess errors)
UNRESOLVED: gcc.target/i386/pr64905.c scan-assembler-not movl[ \\t]0\\\\(%.*\\\\), %.*
FAIL: gcc.target/i386/pr68961.c scan-assembler-not mov
FAIL: gcc.target/i386/pr70155-1.c scan-assembler-not \\\\*movdi_internal
FAIL: gcc.target/i386/pr70155-15.c scan-assembler-not \\\\*movdi_internal
FAIL: gcc.target/i386/pr70155-17.c scan-assembler-not \\\\*movdi_internal
FAIL: gcc.target/i386/pr70155-2.c scan-assembler-not \\\\*movdi_internal
FAIL: gcc.target/i386/pr70155-22.c scan-assembler-not \\\\*movdi_internal
FAIL: gcc.target/i386/pr70155-3.c scan-assembler-not \\\\*movdi_internal
FAIL: gcc.target/i386/pr70155-4.c scan-assembler-not \\\\*movdi_internal
FAIL: gcc.target/i386/pr70155-5.c scan-assembler-not \\\\*movdi_internal
FAIL: gcc.target/i386/pr70155-6.c scan-assembler-not \\\\*movdi_internal
FAIL: gcc.target/i386/pr70155-7.c scan-assembler-not \\\\*movdi_internal
FAIL: gcc.target/i386/pr70155-8.c scan-assembler-not \\\\*movdi_internal
FAIL: gcc.target/i386/pr81502.c scan-assembler-times mov 1
FAIL: gcc.target/i386/pr81736-1.c scan-assembler-not %[re]bp
FAIL: gcc.target/i386/pr81736-2.c scan-assembler-not %[re]bp
FAIL: gcc.target/i386/pr81736-5.c scan-assembler-not %[re]bp
FAIL: gcc.target/i386/pr81736-5.c scan-assembler-not and[^\\n\\r]*sp
FAIL: gcc.target/i386/pr81736-6.c scan-assembler-not %[re]bp
FAIL: gcc.target/i386/pr81736-7.c scan-assembler-not %[re]bp
FAIL: gcc.target/i386/pr81769-1a.c scan-assembler-not and[^\\n\\r]*sp
FAIL: gcc.target/i386/pr81769-1b.c scan-assembler-not and[^\\n\\r]*sp
FAIL: gcc.target/i386/pr85667-10.c scan-assembler-times addsd[ \\t]*40\\\\(%rsp\\\\), .* 1
FAIL: gcc.target/i386/pr85667-8.c scan-assembler-times addss[ \\t]*40\\\\(%rsp\\\\), .* 1
FAIL: gcc.target/i386/pr90765-1.c scan-assembler-not and[lq]?[\\\\t ]*\\\\\$-64,[\\\\t ]*%[re]?sp
FAIL: gcc.target/i386/pr92905.c scan-assembler-not rsp
FAIL: gcc.target/i386/shrink_wrap_1.c scan-rtl-dump pro_and_epilogue "Performing shrink-wrapping"
FAIL: gcc.target/i386/sibcall-1.c scan-assembler-not mov
FAIL: gcc.target/i386/sibcall-7.c scan-assembler-not mov
FAIL: gcc.target/i386/stack-check-12.c scan-assembler pushq\\t%rax
FAIL: gcc.target/i386/stack-check-12.c scan-assembler popq\\t%rax
FAIL: gcc.target/i386/stack-check-17.c scan-assembler-times push[ql] 2
FAIL: compiler driver --help=common option(s): "^ +-.*[^:.]\$" absent from output: "  -fstrict-calling-conventions Use strict ABI calling conventions even for static functions"
FAIL: gcc.dg/initpri1.c execution test
FAIL: gcc.dg/initpri3.c execution test
FAIL: gcc.dg/ipa/ipa-icf-38.c scan-ltrans-tree-dump-not optimized "Function bar"
FAIL: gcc.dg/lto/20081120-1 c_lto_20081120-1_0.o-c_lto_20081120-1_1.o link, -flto -r -nostdlib
FAIL: gcc.dg/lto/20081120-2 c_lto_20081120-2_0.o-c_lto_20081120-2_1.o link, -flto -flto-partition=1to1 -r -nostdlib
FAIL: gcc.dg/lto/20081126 c_lto_20081126_0.o-c_lto_20081126_0.o link, -flto -r -nostdlib
FAIL: gcc.dg/lto/20081204-1 c_lto_20081204-1_0.o-c_lto_20081204-1_1.o link, -flto -flto-partition=1to1 -fPIC -r -nostdlib
FAIL: gcc.dg/lto/20081204-2 c_lto_20081204-2_0.o-c_lto_20081204-2_0.o link, -w -flto -fPIC -r -nostdlib
FAIL: gcc.dg/lto/20081212-1 c_lto_20081212-1_0.o-c_lto_20081212-1_0.o link, -r -nostdlib
FAIL: gcc.dg/lto/20081224 c_lto_20081224_0.o-c_lto_20081224_1.o link, -flto -flto-partition=1to1 -r -nostdlib -fPIC
FAIL: gcc.dg/lto/20090116 c_lto_20090116_0.o-c_lto_20090116_0.o link, -O1 -flto -flto-partition=1to1 -fPIC
FAIL: gcc.dg/lto/20090126-1 c_lto_20090126-1_0.o-c_lto_20090126-1_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20090126-2 c_lto_20090126-2_0.o-c_lto_20090126-2_0.o link, -fPIC -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20090219 c_lto_20090219_0.o-c_lto_20090219_0.o link, -O3 -flto -flto-partition=1to1 -fPIC -r -nostdlib
FAIL: gcc.dg/lto/20091013-1 c_lto_20091013-1_0.o-c_lto_20091013-1_2.o link, -fPIC -r -nostdlib -O2 -flto
FAIL: gcc.dg/lto/20091013-1 c_lto_20091013-1_0.o-c_lto_20091013-1_2.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091014-1 c_lto_20091014-1_0.o-c_lto_20091014-1_0.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091015-1 c_lto_20091015-1_0.o-c_lto_20091015-1_2.o link, -fPIC -r -nostdlib -O2 -flto
FAIL: gcc.dg/lto/20091015-1 c_lto_20091015-1_0.o-c_lto_20091015-1_2.o link, -fPIC -r -nostdlib -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20091016-1 c_lto_20091016-1_0.o-c_lto_20091016-1_1.o link, -fPIC -r -nostdlib -O2 -flto
FAIL: gcc.dg/lto/20091020-1 c_lto_20091020-1_0.o-c_lto_20091020-1_1.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091020-2 c_lto_20091020-2_0.o-c_lto_20091020-2_1.o link, -fPIC -r -nostdlib -flto
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O0 -flto
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O2 -flto
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20091027-1 c_lto_20091027-1_0.o-c_lto_20091027-1_1.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100426 c_lto_20100426_0.o-c_lto_20100426_0.o link, -r -nostdlib -flto -g
FAIL: gcc.dg/lto/20100430-1 c_lto_20100430-1_0.o-c_lto_20100430-1_0.o link, -O2 -fprofile-arcs -flto -r -nostdlib
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O0 -flto
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O2 -flto
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-1 c_lto_20100603-1_0.o-c_lto_20100603-1_0.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O0 -flto
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O2 -flto
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-2 c_lto_20100603-2_0.o-c_lto_20100603-2_0.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O0 -flto
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O0 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O0 -flto -flto-partition=none
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O2 -flto
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O2 -flto -flto-partition=1to1
FAIL: gcc.dg/lto/20100603-3 c_lto_20100603-3_0.o-c_lto_20100603-3_0.o link, -O2 -flto -flto-partition=none
FAIL: gcc.dg/lto/20111213-1 c_lto_20111213-1_0.o-c_lto_20111213-1_0.o link,  -flto -g
FAIL: gcc.dg/lto/pr45736 c_lto_pr45736_0.o-c_lto_pr45736_0.o link, -flto -r -O
FAIL: gcc.dg/lto/pr54702 c_lto_pr54702_0.o-c_lto_pr54702_1.o link,  -O2 -flto -w
FAIL: gcc.dg/lto/pr59323 c_lto_pr59323_0.o-c_lto_pr59323_0.o link,  -O2 -g -flto
FAIL: gcc.dg/lto/pr59323-2 c_lto_pr59323-2_0.o-c_lto_pr59323-2_0.o link,  -O2 -g -flto
FAIL: gcc.dg/lto/pr60820 c_lto_pr60820_0.o-c_lto_pr60820_1.o link, -flto -r -nostdlib -O2
FAIL: gcc.dg/lto/pr81406 c_lto_pr81406_0.o-c_lto_pr81406_0.o link,  -O2 -g -flto
FAIL: gcc.dg/lto/pr83388 c_lto_pr83388_0.o-c_lto_pr83388_0.o link,  -O0 -flto -fsanitize=null
FAIL: gcc.dg/lto/pr83388 c_lto_pr83388_0.o-c_lto_pr83388_0.o link,  -O2 -flto -fsanitize=null
FAIL: gcc.dg/lto/pr85870 c_lto_pr85870_0.o-c_lto_pr85870_1.o link,  -flto -O2
FAIL: gcc.dg/stack-check-5.c scan-rtl-dump-times pro_and_epilogue "Stack clash frame pointer needed" 2
FAIL: gcc.dg/stack-check-5.c scan-rtl-dump-times pro_and_epilogue "Stack clash no frame pointer needed" 2
FAIL: gcc.dg/stack-check-5.c scan-rtl-dump-times pro_and_epilogue "Stack clash no residual allocation in prologue" 1
FAIL: gcc.dg/stack-check-5.c scan-rtl-dump-times pro_and_epilogue "Stack clash residual allocation in prologue" 3
FAIL: gcc.dg/stack-check-6.c scan-rtl-dump-times pro_and_epilogue "Stack clash frame pointer needed" 2
FAIL: gcc.dg/stack-check-6.c scan-rtl-dump-times pro_and_epilogue "Stack clash no frame pointer needed" 2
FAIL: gcc.dg/stack-check-6a.c scan-rtl-dump-times pro_and_epilogue "Stack clash frame pointer needed" 2
FAIL: gcc.dg/stack-check-6a.c scan-rtl-dump-times pro_and_epilogue "Stack clash no frame pointer needed" 2
FAIL: gcc.dg/tree-ssa/pr43491.c (test for excess errors)
FAIL: gcc.target/i386/align-limit.c scan-assembler .p2align 6,,1
FAIL: gcc.target/i386/amd64-abi-3.c scan-assembler subq[\\\\t ]*\\\\\$88,[\\\\t ]*%rsp
FAIL: gcc.target/i386/fuse-caller-save-rec.c scan-assembler-not push
FAIL: gcc.target/i386/fuse-caller-save.c scan-assembler-not push
FAIL: gcc.target/i386/ipa-stack-alignment-2.c scan-assembler sub.*%.sp
FAIL: gcc.target/i386/ipa-stack-alignment.c scan-assembler sub.*%.sp
FAIL: gcc.target/i386/max-stack-align.c (test for excess errors)
FAIL: gcc.target/i386/minmax-6.c scan-assembler-not rsp
FAIL: gcc.target/i386/minmax-7.c scan-assembler-not rsp
FAIL: gcc.target/i386/pad-1.c scan-assembler rep
FAIL: gcc.target/i386/pad-2.c scan-assembler-times nop 8
FAIL: gcc.target/i386/pad-5b.c scan-assembler-times nop 4
FAIL: gcc.target/i386/pad-6b.c scan-assembler-times nop 6
FAIL: gcc.target/i386/pad-8.c scan-assembler-times nop 6
FAIL: gcc.target/i386/pad-9.c scan-assembler-times nop 4
FAIL: gcc.target/i386/pr22076.c scan-assembler-times movq 2
FAIL: gcc.target/i386/pr32661-1.c scan-assembler-times mov 2
FAIL: gcc.target/i386/pr34256.c scan-assembler-times mov 3
FAIL: gcc.target/i386/pr36246.c scan-assembler-not movq
FAIL: gcc.target/i386/pr46470.c scan-assembler-not sp
FAIL: gcc.target/i386/pr47735.c scan-assembler-not %[re]bp
FAIL: gcc.target/i386/pr48037-1.c scan-assembler-not %rsp
FAIL: gcc.target/i386/pr58066.c scan-rtl-dump final "Function foo.*set[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*plus[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*const_int -8.*UNSPEC_TLS.*Function goo"
FAIL: gcc.target/i386/pr58066.c scan-rtl-dump final "Function goo.*set[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*plus[^\\r\\n]*sp\\\\)[\\r\\n][^\\r\\n]*const_int -8.*UNSPEC_TLS"
FAIL: gcc.target/i386/pr59501-1a.c scan-assembler-not and[^\\n\\r]*sp
FAIL: gcc.target/i386/pr59501-2a.c scan-assembler-not and[^\\n\\r]*sp
FAIL: gcc.target/i386/pr59501-3a.c scan-assembler-not and[^\\n\\r]*sp
FAIL: gcc.target/i386/pr59501-4a.c scan-assembler-not and[^\\n\\r]*sp
FAIL: gcc.target/i386/pr64905.c (internal compiler error)
FAIL: gcc.target/i386/pr64905.c (test for excess errors)
UNRESOLVED: gcc.target/i386/pr64905.c scan-assembler-not movl[ \\t]0\\\\(%.*\\\\), %.*
FAIL: gcc.target/i386/pr68961.c scan-assembler-not mov
FAIL: gcc.target/i386/pr70155-1.c scan-assembler-not \\\\*movdi_internal
FAIL: gcc.target/i386/pr70155-15.c scan-assembler-not \\\\*movdi_internal
FAIL: gcc.target/i386/pr70155-17.c scan-assembler-not \\\\*movdi_internal
FAIL: gcc.target/i386/pr70155-2.c scan-assembler-not \\\\*movdi_internal
FAIL: gcc.target/i386/pr70155-22.c scan-assembler-not \\\\*movdi_internal
FAIL: gcc.target/i386/pr70155-3.c scan-assembler-not \\\\*movdi_internal
FAIL: gcc.target/i386/pr70155-4.c scan-assembler-not \\\\*movdi_internal
FAIL: gcc.target/i386/pr70155-5.c scan-assembler-not \\\\*movdi_internal
FAIL: gcc.target/i386/pr70155-6.c scan-assembler-not \\\\*movdi_internal
FAIL: gcc.target/i386/pr70155-7.c scan-assembler-not \\\\*movdi_internal
FAIL: gcc.target/i386/pr70155-8.c scan-assembler-not \\\\*movdi_internal
FAIL: gcc.target/i386/pr81502.c scan-assembler-times mov 1
FAIL: gcc.target/i386/pr81736-1.c scan-assembler-not %[re]bp
FAIL: gcc.target/i386/pr81736-2.c scan-assembler-not %[re]bp
FAIL: gcc.target/i386/pr81736-5.c scan-assembler-not %[re]bp
FAIL: gcc.target/i386/pr81736-5.c scan-assembler-not and[^\\n\\r]*sp
FAIL: gcc.target/i386/pr81736-6.c scan-assembler-not %[re]bp
FAIL: gcc.target/i386/pr81736-7.c scan-assembler-not %[re]bp
FAIL: gcc.target/i386/pr81769-1a.c scan-assembler-not and[^\\n\\r]*sp
FAIL: gcc.target/i386/pr81769-1b.c scan-assembler-not and[^\\n\\r]*sp
FAIL: gcc.target/i386/pr85667-10.c scan-assembler-times addsd[ \\t]*40\\\\(%rsp\\\\), .* 1
FAIL: gcc.target/i386/pr85667-8.c scan-assembler-times addss[ \\t]*40\\\\(%rsp\\\\), .* 1
FAIL: gcc.target/i386/pr90765-1.c scan-assembler-not and[lq]?[\\\\t ]*\\\\\$-64,[\\\\t ]*%[re]?sp
FAIL: gcc.target/i386/pr92905.c scan-assembler-not rsp
FAIL: gcc.target/i386/shrink_wrap_1.c scan-rtl-dump pro_and_epilogue "Performing shrink-wrapping"
FAIL: gcc.target/i386/sibcall-1.c scan-assembler-not mov
FAIL: gcc.target/i386/sibcall-7.c scan-assembler-not mov
FAIL: gcc.target/i386/stack-check-12.c scan-assembler popq\\t%rax
FAIL: gcc.target/i386/stack-check-12.c scan-assembler pushq\\t%rax
FAIL: gcc.target/i386/stack-check-17.c scan-assembler-times push[ql] 2
FAIL: gcc.target/i386/stackalign/pr39146.c -mno-stackrealign  scan-assembler-not and[lq]?[^\\\\n]*-32,[^\\\\n]*sp
FAIL: gcc.target/i386/stackalign/pr39146.c -mstackrealign  scan-assembler-not and[lq]?[^\\\\n]*-32,[^\\\\n]*sp
FAIL: gcc.target/i386/stackalign/pr88483-1.c -mno-stackrealign  scan-assembler-not and[lq]?[^\\\\n]*-[0-9]+,[^\\\\n]*sp
FAIL: gcc.target/i386/stackalign/pr88483-1.c -mstackrealign  scan-assembler-not and[lq]?[^\\\\n]*-[0-9]+,[^\\\\n]*sp
FAIL: gcc.target/i386/stackalign/pr88483-2.c -mno-stackrealign  scan-assembler-not (sub|add)(l|q)[\\\\t ]*\\\\\$[0-9]*,[\\\\t ]*%[re]?sp
FAIL: gcc.target/i386/stackalign/pr88483-2.c -mno-stackrealign  scan-assembler-not and[lq]?[^\\\\n]*-[0-9]+,[^\\\\n]*sp
FAIL: gcc.target/i386/stackalign/pr88483-2.c -mstackrealign  scan-assembler-not (sub|add)(l|q)[\\\\t ]*\\\\\$[0-9]*,[\\\\t ]*%[re]?sp
FAIL: gcc.target/i386/stackalign/pr88483-2.c -mstackrealign  scan-assembler-not and[lq]?[^\\\\n]*-[0-9]+,[^\\\\n]*sp
FAIL: gcc.target/i386/stackalign/return-4.c -mno-stackrealign  scan-assembler-not and[lq]?[^\\\\n]*-64,[^\\\\n]*sp
FAIL: gcc.target/i386/stackalign/return-4.c -mstackrealign  scan-assembler-not and[lq]?[^\\\\n]*-64,[^\\\\n]*sp
FAIL: gcc.target/i386/vartrack-1.c scan-rtl-dump-times vartrack "[0-9][0-9]*: {\\\\[argp:DI-0x10\\\\]=bx:DI;sp:DI=argp:DI-0x10;}" 1
FAIL: gcc.target/i386/vartrack-1.c scan-rtl-dump-times vartrack "[0-9][0-9]*: {bx:DI=\\\\[argp:DI-0x10\\\\];sp:DI=argp:DI-0x8;}" 1
FAIL: gcc.target/x86_64/abi/callabi/leaf-1.c scan-assembler-not %rsp
FAIL: gcc.target/x86_64/abi/callabi/leaf-2.c scan-assembler-not %rsp
FAIL: gcc.target/i386/vartrack-1.c scan-rtl-dump-times vartrack "[0-9][0-9]*: {\\\\[argp:DI-0x10\\\\]=bx:DI;sp:DI=argp:DI-0x10;}" 1
FAIL: gcc.target/i386/vartrack-1.c scan-rtl-dump-times vartrack "[0-9][0-9]*: {bx:DI=\\\\[argp:DI-0x10\\\\];sp:DI=argp:DI-0x8;}" 1
FAIL: gcc.target/i386/stackalign/pr39146.c -mstackrealign  scan-assembler-not and[lq]?[^\\\\n]*-32,[^\\\\n]*sp
FAIL: gcc.target/i386/stackalign/pr88483-1.c -mstackrealign  scan-assembler-not and[lq]?[^\\\\n]*-[0-9]+,[^\\\\n]*sp
FAIL: gcc.target/i386/stackalign/pr88483-2.c -mstackrealign  scan-assembler-not (sub|add)(l|q)[\\\\t ]*\\\\\$[0-9]*,[\\\\t ]*%[re]?sp
FAIL: gcc.target/i386/stackalign/pr88483-2.c -mstackrealign  scan-assembler-not and[lq]?[^\\\\n]*-[0-9]+,[^\\\\n]*sp
FAIL: gcc.target/i386/stackalign/return-4.c -mstackrealign  scan-assembler-not and[lq]?[^\\\\n]*-64,[^\\\\n]*sp
FAIL: gcc.target/i386/stackalign/pr39146.c -mno-stackrealign  scan-assembler-not and[lq]?[^\\\\n]*-32,[^\\\\n]*sp
FAIL: gcc.target/i386/stackalign/pr88483-1.c -mno-stackrealign  scan-assembler-not and[lq]?[^\\\\n]*-[0-9]+,[^\\\\n]*sp
FAIL: gcc.target/i386/stackalign/pr88483-2.c -mno-stackrealign  scan-assembler-not (sub|add)(l|q)[\\\\t ]*\\\\\$[0-9]*,[\\\\t ]*%[re]?sp
FAIL: gcc.target/i386/stackalign/pr88483-2.c -mno-stackrealign  scan-assembler-not and[lq]?[^\\\\n]*-[0-9]+,[^\\\\n]*sp
FAIL: gcc.target/i386/stackalign/return-4.c -mno-stackrealign  scan-assembler-not and[lq]?[^\\\\n]*-64,[^\\\\n]*sp
FAIL: gcc.target/x86_64/abi/callabi/leaf-1.c scan-assembler-not %rsp
FAIL: gcc.target/x86_64/abi/callabi/leaf-2.c scan-assembler-not %rsp

                === gcc Summary for unix//-m64/-msave-args ===

# of expected passes            144728
# of unexpected failures        143
# of expected failures          696
# of unresolved testcases       1
# of unsupported tests          2440

                === gcc Summary ===

# of expected passes            433677
# of unexpected failures        334
# of unexpected successes       2
# of expected failures          2097
# of unresolved testcases       3
# of unsupported tests          7934
```
```
