### PR TITLE
Allow use of dragonfly locale code so non-C locales work.

### DIFF
--- a/libstdc++-v3/acinclude.m4
+++ b/libstdc++-v3/acinclude.m4
@@ -2774,7 +2774,7 @@ dnl
 AC_DEFUN([GLIBCXX_ENABLE_CLOCALE], [
   GLIBCXX_ENABLE(clocale,auto,[[[=MODEL]]],
     [use MODEL for target locale package],
-    [permit generic|gnu|ieee_1003.1-2001|newlib|yes|no|auto])
+    [permit generic|gnu|ieee_1003.1-2001|newlib|dragonfly|yes|no|auto])
 
   # Deal with gettext issues.  Default to not using it (=no) until we detect
   # support for it later.  Let the user turn it off via --e/d, but let that

--- a/libstdc++-v3/config/locale/dragonfly/ctype_members.cc
+++ b/libstdc++-v3/config/locale/dragonfly/ctype_members.cc
@@ -135,6 +135,66 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
     return __hi;
   }
 
+/*
+ * Taken verbatim from config/locale/generic/ctype_members.cc.  DragonFly
+ * implements these in config/os/bsd/dragonfly/ctype_inline.h.
+ */
+#if defined(__illumos__)
+  bool
+  ctype<wchar_t>::
+  do_is(mask __m, char_type __c) const
+  {
+    bool __ret = false;
+    // Generically, 15 (instead of 11) since we don't know the numerical
+    // encoding of the various categories in /usr/include/ctype.h.
+    const size_t __bitmasksize = 15;
+    for (size_t __bitcur = 0; __bitcur <= __bitmasksize; ++__bitcur)
+      if (__m & _M_bit[__bitcur]
+          && iswctype(__c, _M_wmask[__bitcur]))
+        {
+          __ret = true;
+          break;
+        }
+    return __ret;
+  }
+
+  const wchar_t*
+  ctype<wchar_t>::
+  do_is(const wchar_t* __lo, const wchar_t* __hi, mask* __vec) const
+  {
+    for (;__lo < __hi; ++__vec, ++__lo)
+      {
+        // Generically, 15 (instead of 11) since we don't know the numerical
+        // encoding of the various categories in /usr/include/ctype.h.
+        const size_t __bitmasksize = 15;
+        mask __m = 0;
+        for (size_t __bitcur = 0; __bitcur <= __bitmasksize; ++__bitcur)
+          if (iswctype(*__lo, _M_wmask[__bitcur]))
+            __m |= _M_bit[__bitcur];
+        *__vec = __m;
+      }
+    return __hi;
+  }
+
+  const wchar_t*
+  ctype<wchar_t>::
+  do_scan_is(mask __m, const wchar_t* __lo, const wchar_t* __hi) const
+  {
+    while (__lo < __hi && !this->do_is(__m, *__lo))
+      ++__lo;
+    return __lo;
+  }
+
+  const wchar_t*
+  ctype<wchar_t>::
+  do_scan_not(mask __m, const char_type* __lo, const char_type* __hi) const
+  {
+    while (__lo < __hi && this->do_is(__m, *__lo) != 0)
+      ++__lo;
+    return __lo;
+  }
+#endif
+
   wchar_t
   ctype<wchar_t>::
   do_widen(char __c) const

--- a/libstdc++-v3/config/locale/dragonfly/ctype_members.cc
+++ b/libstdc++-v3/config/locale/dragonfly/ctype_members.cc
@@ -138,6 +138,9 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 /*
  * Taken verbatim from config/locale/generic/ctype_members.cc.  DragonFly
  * implements these in config/os/bsd/dragonfly/ctype_inline.h.
+ *
+ * The mask type and individual mask bits are defined in
+ * libstdc++-v3/config/os/solaris/ctype_base.h to match libc's ctype mask bits.
  */
 #if defined(__illumos__)
   bool

--- a/libstdc++-v3/config/locale/dragonfly/monetary_members.cc
+++ b/libstdc++-v3/config/locale/dragonfly/monetary_members.cc
@@ -37,9 +37,35 @@ namespace std _GLIBCXX_VISIBILITY(default)
 {
 _GLIBCXX_BEGIN_NAMESPACE_VERSION
 
+  extern wchar_t lconv2wchar(const char *conv, wchar_t def, locale_t __cloc);
+  extern char lconv2char(const char *conv, char def);
+
 // This file might be compiled twice, but we only want to define the members
 // of money_base once.
 #if ! _GLIBCXX_USE_CXX11_ABI
+
+  wchar_t lconv2wchar(const char *conv, wchar_t def, locale_t __cloc)
+  {
+    wchar_t w = def;
+    const size_t tlen = strlen(conv);
+    if (tlen == 1)
+      w = (wchar_t) conv[0];
+
+    int clen = mbtowc_l(&w, conv, tlen, __cloc);
+    if (clen <= 0)
+      return def;
+    else
+      return w;
+  }
+
+  char lconv2char(const char *conv, char def)
+  {
+    char w = def;
+    const size_t tlen = strlen(conv);
+    if (tlen == 1)
+      w = conv[0];
+    return w;
+  }
 
   // Construct and return valid pattern consisting of some combination of:
   // space none symbol sign value
@@ -283,7 +309,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 		}
 	      else
 		{
-	          _M_data->_M_thousands_sep = lc->mon_thousands_sep[0];
+		  _M_data->_M_thousands_sep = lconv2char(lc->mon_thousands_sep, ',');
 
 		  __len = strlen(__cgroup);
 		  if (__len)
@@ -437,7 +463,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 		}
 	      else
 		{
-	          _M_data->_M_thousands_sep = lc->mon_thousands_sep[0];
+		  _M_data->_M_thousands_sep = lconv2char(lc->mon_thousands_sep, ',');
 
 		  __len = strlen(__cgroup);
 		  if (__len)
@@ -624,8 +650,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 		}
 	      else
 		{
-		  _M_data->_M_thousands_sep =
-			(wchar_t)lc->mon_thousands_sep[0];
+		  _M_data->_M_thousands_sep = lconv2wchar(lc->mon_thousands_sep, L',', (locale_t)__cloc);
 		  __len = strlen(__cgroup);
 		  if (__len)
 		    {
@@ -784,8 +809,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 		}
 	      else
 		{
-		  _M_data->_M_thousands_sep =
-			(wchar_t)lc->mon_thousands_sep[0];
+		  _M_data->_M_thousands_sep = lconv2wchar(lc->mon_thousands_sep, L',', (locale_t)__cloc);
 		  __len = strlen(__cgroup);
 		  if (__len)
 		    {

--- a/libstdc++-v3/config/locale/dragonfly/numeric_members.cc
+++ b/libstdc++-v3/config/locale/dragonfly/numeric_members.cc
@@ -37,6 +37,9 @@ namespace std _GLIBCXX_VISIBILITY(default)
 {
 _GLIBCXX_BEGIN_NAMESPACE_VERSION
 
+  extern wchar_t lconv2wchar(const char *conv, wchar_t def, locale_t __cloc);
+  extern char lconv2char(const char *conv, char def);
+
   template<>
     void
     numpunct<char>::_M_initialize_numpunct(__c_locale __cloc)
@@ -86,7 +89,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	    }
 	  else
 	    {
-	      _M_data->_M_thousands_sep = lc->thousands_sep[0];
+	      _M_data->_M_thousands_sep = lconv2char(lc->thousands_sep, ',');
 
 	      const char* __src = lc->grouping;
 	      const size_t __len = strlen(__src);
@@ -185,7 +188,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	    }
 	  else
 	    {
-	      _M_data->_M_thousands_sep = (wchar_t)lc->thousands_sep[0];
+	      _M_data->_M_thousands_sep = lconv2wchar(lc->thousands_sep, L',', (locale_t)__cloc);
 
   	      const char* __src = lc->grouping;
 	      const size_t __len = strlen(__src);

--- a/libstdc++-v3/configure
+++ b/libstdc++-v3/configure
@@ -16635,7 +16635,7 @@ $as_echo "stdio (with POSIX read/write)" >&6; }
 if test "${enable_clocale+set}" = set; then :
   enableval=$enable_clocale;
       case "$enableval" in
-       generic|gnu|ieee_1003.1-2001|newlib|yes|no|auto) ;;
+       generic|gnu|ieee_1003.1-2001|newlib|dragonfly|yes|no|auto) ;;
        *) as_fn_error $? "Unknown argument to enable/disable clocale" "$LINENO" 5 ;;
 	  	        esac
 


### PR DESCRIPTION
This tweaks the libstdc++ `configure` script to let you pass `--enable-clocale=dragonfly` to select the dragonfly locale code; this will only work on illumos if you also have the illumos-gate changes in https://code.illumos.org/c/illumos-gate/+/4242 

The `ctype_members.cc` patch is from Jonathan Perkin's patch in pkgsrc-extra and is needed to avoid undefined symbols.
